### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-This page is used as a starting point for contributing to the development of `gz-yarp-plugins`.
+This page is used as a starting point for contributing to the development of `gz-sim-yarp-plugins`.
 
-If you would like to contribute to the development of `gazebo-yarp-plugins`, please get in contact with the development team using [GitHub issues](https://github.com/robotology/gz-sim-yarp-plugins/issues).
+If you would like to contribute to the development of `gz-sim-yarp-plugins`, please get in contact with the development team using [GitHub issues](https://github.com/robotology/gz-sim-yarp-plugins/issues).
 
 If you need a new feature or to fix a bug, please [fill a GitHub issue](https://github.com/robotology/gz-sim-yarp-plugins/issues/new) describing the feature or the bugfix you would like to implement.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,4 @@ In a nutshell, development of new features/bugfixes happens in separated branch.
 you can open a pull request against master, where your code will be review by other contributors prior to merging it.
 
 > [!NOTE]  
-> **For maintainers:** Every time a new PR has to be merged in the `main` branch, the merge mode to use is [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits). This will help the blame of code changes, maintain a cleaner history on the `main` branch and facilitate code bisection for regression issues.
+> **For maintainers:** Every time a new PR has to be merged in the `main` branch, the merge mode to use is [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) unless the commits in the PR are not already curated. This will help the blame of code changes, maintain a cleaner history on the `main` branch and facilitate code bisection for regression issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+This page is used as a starting point for contributing to the development of `gz-yarp-plugins`.
+
+If you would like to contribute to the development of `gazebo-yarp-plugins`, please get in contact with the development team using [GitHub issues](https://github.com/robotology/gz-sim-yarp-plugins/issues).
+
+If you need a new feature or to fix a bug, please [fill a GitHub issue](https://github.com/robotology/gz-sim-yarp-plugins/issues/new) describing the feature or the bugfix you would like to implement.
+
+## Code style
+
+We adopt a consistent code style.
+If you want to contribute to this project, we kindly ask you to conform to the code style guidelines.
+
+We do not enforce the style (at least at the current stage) but we will probably offer scripts to ease the process in the future.
+
+More precisely, we try to use the **WebKit** coding style (see [WebKit page](http://www.webkit.org/coding/coding-style.html)).
+
+## Patches and features contribution
+
+The contribution follows the classical GitHub stages:
+
+* open an issue (so we can discuss the problem and possible solutions);
+* develop the changes;
+* fork the project and submit the pull request.
+
+## Repository structure and releases management
+
+This part is mainly targeted to ''internal'' members.
+
+Development of new features follows the [GitHub Flow](https://guides.github.com/introduction/flow/index.html) ( also know as [Feature Branch Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) ).
+
+In a nutshell, development of new features/bugfixes happens in separated branch. When you believe your contribution is stable
+you can open a pull request against master, where your code will be review by other contributors prior to merging it.
+
+[!NOTE]  
+> **For maintainers:** Every time a new PR has to be merged in the `main` branch, the merge mode to use is [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits). This will help the blame of code changes, maintain a cleaner history on the `main` branch and facilitate code bisection for regression issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,5 +32,5 @@ Development of new features follows the [GitHub Flow](https://guides.github.com/
 In a nutshell, development of new features/bugfixes happens in separated branch. When you believe your contribution is stable
 you can open a pull request against master, where your code will be review by other contributors prior to merging it.
 
-[!NOTE]  
+> [!NOTE]  
 > **For maintainers:** Every time a new PR has to be merged in the `main` branch, the merge mode to use is [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits). This will help the blame of code changes, maintain a cleaner history on the `main` branch and facilitate code bisection for regression issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,7 @@ If you need a new feature or to fix a bug, please [fill a GitHub issue](https://
 We adopt a consistent code style.
 If you want to contribute to this project, we kindly ask you to conform to the code style guidelines.
 
-We do not enforce the style (at least at the current stage) but we will probably offer scripts to ease the process in the future.
-
-More precisely, we try to use the **WebKit** coding style (see [WebKit page](http://www.webkit.org/coding/coding-style.html)).
+To enforce our coding style we are using the [clang-format](https://clang.llvm.org/docs/ClangFormat.html) code formatting tool, through the [.clang-format](.clang-format) file. The majority of IDEs and editors automatically detect this file and apply the formatting automatically (e.g. when saving). For example, for Visual Studio Code see [the official documentation](https://code.visualstudio.com/docs/cpp/cpp-ide#_code-formatting).
 
 ## Patches and features contribution
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gz-sim-yarp-plugins
 
-**This repository contains a preliminary work in progress of integration of Modern Gazebo (gz) and YARP devices, a port of some functionalities of https://github.com/robotology/gazebo-yarp-plugins to Modern Gazebo. The repo is working in progress, and public interfaces can change without warning.**
+[!WARNING]  
+> This repository contains a preliminary work in progress of integration of Modern Gazebo (gz) and YARP devices, a port of some functionalities of <https://github.com/robotology/gazebo-yarp-plugins> to Modern Gazebo. \
+> The repo is working in progress, and public interfaces can change without warning.
 
 ## Installation
 
@@ -19,6 +21,7 @@ mamba activate gsypdev
 All the commands in this README should be executed in a terminal with the activated environment.
 
 Then, compile gz-sim-yarp-plugins itself, using the following commands on Linux and macOS:
+
 ~~~
 git clone https://github.dev/robotology/gz-sim-yarp-plugins
 mkdir build
@@ -29,6 +32,7 @@ ninja install
 ~~~
 
 or the following commands on Windows:
+
 ~~~
 git clone https://github.dev/robotology/gz-sim-yarp-plugins
 mkdir build
@@ -38,9 +42,7 @@ ninja
 ninja install
 ~~~
 
-
 ### Compile from source using apt dependencies on Linux, macOS or Windows
-
 
 First install some necessary dependencies from apt  
 
@@ -107,6 +109,7 @@ Once the plugins are available, you can see how to use the different plugins by 
 ## Run Tests
 
 To run the tests, just configure the project with the `BUILD_TESTING` option, and run `ctest`:
+
 ~~~
 cd build
 cmake -DBUILD_TESTING:BOOL=ON
@@ -114,3 +117,7 @@ ctest
 ~~~
 
 For more details, check how the tests are run as part of the Continuous Integration, in [`.github/workflows`](.github/workflows).
+
+## Contributing
+
+Refer to the [Contributing page](CONTRIBUTING.md).


### PR DESCRIPTION
This PR adds the CONTRIBUTING.md page, where we specify conventions and workflows to follow to contribute to the repo.

Closes #72 