### PR TITLE
apt CI: Increase until-pass to 20 also for Debug builds

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -104,7 +104,8 @@ jobs:
       if: contains(matrix.build_type, 'Debug')
       run: |
         cd build
-        ctest -T Test -T Coverage --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} . 
+        # So high until-pass as a mitigation for https://github.com/robotology/gz-sim-yarp-plugins/issues/75
+        ctest -T Test -T Coverage --repeat until-pass:20 --output-on-failure -C ${{ matrix.build_type }} . 
       
     - name: Generate a code coverage report
       if: contains(matrix.build_type, 'Debug')


### PR DESCRIPTION
Latest nightly job failed: https://github.com/robotology/gz-sim-yarp-plugins/actions/runs/7750445068 .