### PR TITLE
Add position control mode

### DIFF
--- a/plugins/controlboard/CMakeLists.txt
+++ b/plugins/controlboard/CMakeLists.txt
@@ -3,12 +3,14 @@ set(HEADER_FILES
     include/ControlBoardDriver.hh
     include/ControlBoardDataSingleton.hh
     include/ControlBoardData.hh
+    include/ControlBoardTrajectory.hh
 )
 
 set(SRC_FILES
     src/ControlBoard.cpp
     src/ControlBoardDriver.cpp
     src/ControlBoardDataSingleton.cpp
+    src/ControlBoardTrajectory.cpp
 )
 
 add_library(gz-sim-yarp-controlboard-system SHARED ${HEADER_FILES} ${SRC_FILES})

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -90,6 +90,7 @@ private:
     double convertGazeboToUser(JointProperties& joint, double value);
     double convertUserToGazebo(JointProperties& joint, double value);
     bool setJointPositionLimits(const gz::sim::EntityComponentManager& ecm);
+    bool setTrajectoryGenerators();
 };
 
 } // namespace gzyarp

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -91,6 +91,8 @@ private:
     double convertUserToGazebo(JointProperties& joint, double value);
     bool setJointPositionLimits(const gz::sim::EntityComponentManager& ecm);
     bool setTrajectoryGenerators();
+    bool parseInitialConfiguration(std::vector<double>& initialConfigurations);
+    void resetPositionsAndTrajectoryGenerators(gz::sim::EntityComponentManager& ecm);
 };
 
 } // namespace gzyarp

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -70,6 +70,8 @@ private:
     void updateSimTime(const gz::sim::v7::UpdateInfo& _info);
     bool readJointsMeasurements(const gz::sim::EntityComponentManager& _ecm);
     void checkForJointsHwFault();
+    bool
+    updateTrajectories(const gz::sim::UpdateInfo& _info, gz::sim::EntityComponentManager& _ecm);
     bool updateReferences(const gz::sim::UpdateInfo& _info, gz::sim::EntityComponentManager& _ecm);
     double getJointTorqueFromTransmittedWrench(const gz::sim::Joint& gzJoint,
                                                const gz::msgs::Wrench& wrench,

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -91,8 +91,9 @@ private:
     double convertGazeboGainToUserGain(JointProperties& joint, double value);
     double convertGazeboToUser(JointProperties& joint, double value);
     double convertUserToGazebo(JointProperties& joint, double value);
-    bool setJointPositionLimits(const gz::sim::EntityComponentManager& ecm);
-    bool setTrajectoryGenerators();
+    bool initializeJointPositionLimits(const gz::sim::EntityComponentManager& ecm);
+    bool initializeTrajectoryGenerators();
+    bool initializeTrajectoryGeneratorReferences(yarp::os::Bottle& trajectoryGeneratorsGroup);
     bool parseInitialConfiguration(std::vector<double>& initialConfigurations);
     void resetPositionsAndTrajectoryGenerators(gz::sim::EntityComponentManager& ecm);
 };

--- a/plugins/controlboard/include/ControlBoardData.hh
+++ b/plugins/controlboard/include/ControlBoardData.hh
@@ -2,6 +2,7 @@
 
 #include "ControlBoardTrajectory.hh"
 
+#include <chrono>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -53,6 +54,10 @@ struct JointProperties
         pidControllers;
     std::string positionControlLaw; // TODO: verify usefulness of this field
     std::unique_ptr<yarp::dev::gzyarp::TrajectoryGenerator> trajectoryGenerator;
+    double trajectoryGenerationRefPosition{0.0};
+    double trajectoryGenerationRefSpeed{0.0};
+    double trajectoryGenerationRefAcceleration{0.0};
+    bool isMotionDone{true};
 };
 
 class ControlBoardData
@@ -62,6 +67,9 @@ public:
     std::string modelScopedName;
     std::vector<JointProperties> joints;
     yarp::os::Stamp simTime;
+
+    // TODO (xela95): read this value from configuration file
+    std::chrono::milliseconds controlUpdatePeriod = std::chrono::milliseconds(1);
 };
 
 } // namespace gzyarp

--- a/plugins/controlboard/include/ControlBoardData.hh
+++ b/plugins/controlboard/include/ControlBoardData.hh
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "ControlBoardTrajectory.hh"
+
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -49,6 +52,7 @@ struct JointProperties
     std::unordered_map<yarp::dev::PidControlTypeEnum, gz::math::PID, PidControlTypeEnumHashFunction>
         pidControllers;
     std::string positionControlLaw; // TODO: verify usefulness of this field
+    std::unique_ptr<yarp::dev::gzyarp::TrajectoryGenerator> trajectoryGenerator;
 };
 
 class ControlBoardData

--- a/plugins/controlboard/include/ControlBoardTrajectory.hh
+++ b/plugins/controlboard/include/ControlBoardTrajectory.hh
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <gz/sim/Model.hh>
+
+#include <mutex>
+
+namespace yarp
+{
+namespace dev
+{
+namespace gzyarp
+{
+
+enum TrajectoryType
+{
+    TRAJECTORY_TYPE_CONST_SPEED = 0,
+    TRAJECTORY_TYPE_MIN_JERK = 1,
+    TRAJECTORY_TYPE_TRAP_SPEED = 2
+};
+
+class Watchdog
+{
+    double m_duration;
+    double m_lastUpdate;
+
+public:
+    void reset();
+    bool isExpired();
+    void modifyDuration(double expireTime);
+    double getDuration();
+
+    Watchdog(double expireTime);
+};
+
+class RampFilter
+{
+private:
+    std::mutex m_mutex;
+    double m_final_reference;
+    double m_current_value;
+    double m_step;
+
+public:
+    RampFilter();
+
+    void setReference(double ref, double step);
+    void update();
+    double getCurrentValue();
+    void stop();
+};
+
+class TrajectoryGenerator
+{
+protected:
+    std::mutex m_mutex;
+    gz::sim::Model* m_robot;
+    bool m_trajectory_complete;
+    double m_x0;
+    double m_xf;
+    double m_speed;
+    double m_acceleration;
+    double m_computed_reference;
+    double m_controllerPeriod;
+    double m_joint_min;
+    double m_joint_max;
+    TrajectoryGenerator(gz::sim::Model* model);
+
+public:
+    virtual ~TrajectoryGenerator();
+    virtual bool initTrajectory(double current_pos,
+                                double final_pos,
+                                double speed,
+                                double acceleration,
+                                double controller_period)
+        = 0;
+    virtual bool abortTrajectory(double limit) = 0;
+    virtual double computeTrajectory() = 0;
+    virtual double computeTrajectoryStep() = 0;
+    virtual TrajectoryType getTrajectoryType() = 0;
+    bool setLimits(double min, double max);
+    bool isMotionDone();
+};
+
+class ConstSpeedTrajectoryGenerator : public TrajectoryGenerator
+{
+public:
+    ConstSpeedTrajectoryGenerator(gz::sim::Model* model);
+    virtual ~ConstSpeedTrajectoryGenerator();
+
+private:
+    double p_computeTrajectory();
+    double p_computeTrajectoryStep();
+    bool p_abortTrajectory(double limit);
+
+public:
+    bool initTrajectory(double current_pos,
+                        double final_pos,
+                        double speed,
+                        double acceleration,
+                        double controller_period);
+    bool abortTrajectory(double limit);
+    double computeTrajectory();
+    double computeTrajectoryStep();
+    TrajectoryType getTrajectoryType();
+};
+
+class TrapezoidalSpeedTrajectoryGenerator : public TrajectoryGenerator
+{
+public:
+    TrapezoidalSpeedTrajectoryGenerator(gz::sim::Model* model);
+    virtual ~TrapezoidalSpeedTrajectoryGenerator();
+
+private:
+    double m_ta;
+    double m_tb;
+    double m_tf;
+    double m_tick;
+    double m_v0;
+    double m_computed_reference_velocity;
+
+    double p_computeTrajectoryStep();
+
+public:
+    bool initTrajectory(double current_pos,
+                        double final_pos,
+                        double speed,
+                        double acceleration,
+                        double controller_period);
+    bool abortTrajectory(double limit);
+    double computeTrajectory();
+    double computeTrajectoryStep();
+    TrajectoryType getTrajectoryType();
+};
+
+class MinJerkTrajectoryGenerator : public TrajectoryGenerator
+{
+public:
+    MinJerkTrajectoryGenerator(gz::sim::Model* model);
+    virtual ~MinJerkTrajectoryGenerator();
+
+private:
+    double m_trajectory_coeff_c1;
+    double m_trajectory_coeff_c2;
+    double m_trajectory_coeff_c3;
+    double m_dx0;
+    double m_tf;
+    double m_prev_a;
+    double m_cur_t;
+    double m_cur_step;
+    double m_step;
+
+    double p_computeTrajectory();
+    double p_computeTrajectoryStep();
+    bool p_abortTrajectory(double limit);
+
+    double p_compute_p5f(double t);
+    double p_compute_p5f_vel(double t);
+    double p_compute_current_vel();
+
+public:
+    bool initTrajectory(double current_pos,
+                        double final_pos,
+                        double speed,
+                        double acceleration,
+                        double controller_period);
+    bool abortTrajectory(double limit);
+    double computeTrajectory();
+    double computeTrajectoryStep();
+    TrajectoryType getTrajectoryType();
+};
+
+} // namespace gzyarp
+} // namespace dev
+} // namespace yarp

--- a/plugins/controlboard/include/ControlBoardTrajectory.hh
+++ b/plugins/controlboard/include/ControlBoardTrajectory.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <gz/sim/Model.hh>
 
 #include <yarp/os/Log.h>
@@ -62,7 +63,7 @@ protected:
     double m_speed;
     double m_acceleration;
     double m_computed_reference;
-    double m_controllerPeriod;
+    double m_controllerPeriodMilliseconds;
     double m_joint_min;
     double m_joint_max;
     TrajectoryGenerator();
@@ -73,7 +74,7 @@ public:
                                 double final_pos,
                                 double speed,
                                 double acceleration,
-                                double controller_period)
+                                std::chrono::milliseconds controller_period)
         = 0;
     virtual bool abortTrajectory(double limit) = 0;
     virtual double computeTrajectory() = 0;
@@ -99,7 +100,7 @@ public:
                         double final_pos,
                         double speed,
                         double acceleration,
-                        double controller_period);
+                        std::chrono::milliseconds controller_period);
     bool abortTrajectory(double limit);
     double computeTrajectory();
     double computeTrajectoryStep();
@@ -127,7 +128,7 @@ public:
                         double final_pos,
                         double speed,
                         double acceleration,
-                        double controller_period);
+                        std::chrono::milliseconds controller_period);
     bool abortTrajectory(double limit);
     double computeTrajectory();
     double computeTrajectoryStep();
@@ -164,7 +165,7 @@ public:
                         double final_pos,
                         double speed,
                         double acceleration,
-                        double controller_period);
+                        std::chrono::milliseconds controller_period);
     bool abortTrajectory(double limit);
     double computeTrajectory();
     double computeTrajectoryStep();

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -799,11 +799,10 @@ bool ControlBoardDriver::positionMove(int j, double ref)
 
     joint.trajectoryGenerationRefPosition = ref;
 
-    double limitMin, limitMax;
-    if (!ControlBoardDriver::getLimits(j, &limitMin, &limitMax))
-    {
-        return false;
-    }
+    // TODO: use getLimits when recursive mutexes are implemented
+
+    auto limitMin = m_controlBoardData->joints.at(j).positionLimitMin;
+    auto limitMax = m_controlBoardData->joints.at(j).positionLimitMax;
 
     joint.trajectoryGenerator->setLimits(limitMin, limitMax);
     joint.trajectoryGenerator->initTrajectory(joint.position,

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -4,6 +4,7 @@
 #include "../include/ControlBoardDataSingleton.hh"
 
 #include <cmath>
+#include <cstddef>
 #include <exception>
 #include <mutex>
 #include <string>
@@ -785,141 +786,543 @@ bool ControlBoardDriver::getRefPositions(const int n_joint, const int* joints, d
 
 bool ControlBoardDriver::positionMove(int j, double ref)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while setting reference position for trajectory generation: joint index "
+                        + std::to_string(j) + " out of range";
+        return false;
+    }
+
+    auto& joint = m_controlBoardData->joints.at(j);
+
+    joint.trajectoryGenerationRefPosition = ref;
+
+    double limitMin, limitMax;
+    if (!ControlBoardDriver::getLimits(j, &limitMin, &limitMax))
+    {
+        return false;
+    }
+
+    joint.trajectoryGenerator->setLimits(limitMin, limitMax);
+    joint.trajectoryGenerator->initTrajectory(joint.position,
+                                              joint.trajectoryGenerationRefPosition,
+                                              joint.trajectoryGenerationRefSpeed,
+                                              joint.trajectoryGenerationRefAcceleration,
+                                              m_controlBoardData->controlUpdatePeriod);
+
     return true;
 }
 
 bool ControlBoardDriver::positionMove(const double* refs)
 {
-    // TODO
+    if (!refs)
+    {
+        yError() << "Error while setting reference positions for trajectory generation: refs array "
+                    "is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::positionMove(i, refs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::relativeMove(int j, double delta)
 {
-    // TODO
-    return true;
+    // Check on valid joint number done in setPosition
+    return setPosition(j, m_controlBoardData->joints.at(j).position + delta);
 }
+
 bool ControlBoardDriver::relativeMove(const double* deltas)
 {
-    // TODO
+    if (!deltas)
+    {
+        yError() << "Error while setting relative positions: deltas array is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::relativeMove(i, deltas[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::checkMotionDone(int j, bool* flag)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while checking motion done: joint index out of range";
+        return false;
+    }
+
+    *flag = m_controlBoardData->joints.at(j).isMotionDone;
+
     return true;
 }
+
 bool ControlBoardDriver::checkMotionDone(bool* flag)
 {
-    // TODO
+    if (!flag)
+    {
+        yError() << "Error while checking motion done: flag is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::checkMotionDone(i, &flag[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::setRefSpeed(int j, double sp)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while setting reference speed: joint index out of range";
+        return false;
+    }
+
+    m_controlBoardData->joints.at(j).trajectoryGenerationRefSpeed = sp;
+
     return true;
 }
+
 bool ControlBoardDriver::setRefSpeeds(const double* spds)
 {
-    // TODO
+    if (!spds)
+    {
+        yError() << "Error while setting reference speeds: spds array is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::setRefSpeed(i, spds[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::setRefAcceleration(int j, double acc)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while setting reference acceleration: joint index out of range";
+        return false;
+    }
+
+    m_controlBoardData->joints.at(j).trajectoryGenerationRefAcceleration = acc;
+
     return true;
 }
+
 bool ControlBoardDriver::setRefAccelerations(const double* accs)
 {
-    // TODO
+    if (!accs)
+    {
+        yError() << "Error while setting reference accelerations: accs array is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::setRefAcceleration(i, accs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::getRefSpeed(int j, double* ref)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while getting reference speed: joint index out of range";
+        return false;
+    }
+
+    *ref = m_controlBoardData->joints.at(j).trajectoryGenerationRefSpeed;
+
     return true;
 }
+
 bool ControlBoardDriver::getRefSpeeds(double* spds)
 {
-    // TODO
+    if (!spds)
+    {
+        yError() << "Error while getting reference speeds: spds array is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::getRefSpeed(i, &spds[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::getRefAcceleration(int j, double* acc)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while getting reference acceleration: joint index out of range";
+        return false;
+    }
+
+    *acc = m_controlBoardData->joints.at(j).trajectoryGenerationRefAcceleration;
+
     return true;
 }
+
 bool ControlBoardDriver::getRefAccelerations(double* accs)
 {
-    // TODO
+    if (!accs)
+    {
+        yError() << "Error while getting reference accelerations: accs array is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::getRefAcceleration(i, &accs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::stop(int j)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (j < 0 || j >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while stopping: joint index out of range";
+        return false;
+    }
+
+    switch (m_controlBoardData->joints.at(j).controlMode)
+    {
+    case VOCAB_CM_POSITION:
+        m_controlBoardData->joints.at(j).trajectoryGenerationRefPosition
+            = m_controlBoardData->joints.at(j).position;
+        m_controlBoardData->joints.at(j).trajectoryGenerator->abortTrajectory(
+            m_controlBoardData->joints.at(j).position);
+        break;
+    case VOCAB_CM_POSITION_DIRECT:
+        m_controlBoardData->joints.at(j).trajectoryGenerationRefPosition
+            = m_controlBoardData->joints.at(j).position;
+        m_controlBoardData->joints.at(j).refPosition = m_controlBoardData->joints.at(j).position;
+        break;
+    case VOCAB_CM_VELOCITY:
+        // TODO velocity control
+        yWarning() << "stop not implemented for velocity control mode";
+        break;
+    case VOCAB_CM_MIXED:
+        yWarning() << "stop not implemented for mixed control mode";
+        // TODO mixed control
+        break;
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::stop()
 {
-    // TODO
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::stop(i))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::positionMove(const int n_joint, const int* joints, const double* refs)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while setting reference positions for trajectory generation: joints "
+                    "array is null";
+        return false;
+    }
+    if (!refs)
+    {
+        yError() << "Error while setting reference positions for trajectory generation: refs array "
+                    "is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::positionMove(joints[i], refs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::relativeMove(const int n_joint, const int* joints, const double* deltas)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while setting relative positions: joints array is null";
+        return false;
+    }
+    if (!deltas)
+    {
+        yError() << "Error while setting relative positions: deltas array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::relativeMove(joints[i], deltas[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 bool ControlBoardDriver::checkMotionDone(const int n_joint, const int* joints, bool* flag)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while checking motion done: joints array is null";
+        return false;
+    }
+    if (!flag)
+    {
+        yError() << "Error while checking motion done: flag array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::checkMotionDone(joints[i], &flag[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::setRefSpeeds(const int n_joint, const int* joints, const double* spds)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while setting reference speeds: joints array is null";
+        return false;
+    }
+    if (!spds)
+    {
+        yError() << "Error while setting reference speeds: spds array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::setRefSpeed(joints[i], spds[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 bool ControlBoardDriver::setRefAccelerations(const int n_joint,
                                              const int* joints,
                                              const double* accs)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while setting reference accelerations: joints array is null";
+        return false;
+    }
+    if (!accs)
+    {
+        yError() << "Error while setting reference accelerations: accs array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::setRefAcceleration(joints[i], accs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::getRefSpeeds(const int n_joint, const int* joints, double* spds)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while getting reference speeds: joints array is null";
+        return false;
+    }
+    if (!spds)
+    {
+        yError() << "Error while getting reference speeds: spds array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::getRefSpeed(joints[i], &spds[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::getRefAccelerations(const int n_joint, const int* joints, double* accs)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while getting reference accelerations: joints array is null";
+        return false;
+    }
+    if (!accs)
+    {
+        yError() << "Error while getting reference accelerations: accs array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::getRefAcceleration(joints[i], &accs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 bool ControlBoardDriver::stop(const int n_joint, const int* joints)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while stopping: joints array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::stop(joints[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 
 bool ControlBoardDriver::getTargetPosition(const int joint, double* ref)
 {
-    // TODO
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
+
+    if (joint < 0 || joint >= m_controlBoardData->joints.size())
+    {
+        yError() << "Error while getting target position: joint index " + std::to_string(joint)
+                        + " out of range";
+        return false;
+    }
+
+    *ref = m_controlBoardData->joints.at(joint).trajectoryGenerationRefPosition;
+
     return true;
 }
+
 bool ControlBoardDriver::getTargetPositions(double* refs)
 {
-    // TODO
+    if (!refs)
+    {
+        yError() << "Error while getting target positions: refs array is null";
+        return false;
+    }
+
+    for (size_t i = 0; i < m_controlBoardData->joints.size(); i++)
+    {
+        if (!ControlBoardDriver::getTargetPosition(i, &refs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
+
 bool ControlBoardDriver::getTargetPositions(const int n_joint, const int* joints, double* refs)
 {
-    // TODO
+    if (!joints)
+    {
+        yError() << "Error while getting target positions: joints array is null";
+        return false;
+    }
+    if (!refs)
+    {
+        yError() << "Error while getting target positions: refs array is null";
+        return false;
+    }
+
+    for (int i = 0; i < n_joint; i++)
+    {
+        if (!ControlBoardDriver::getTargetPosition(joints[i], &refs[i]))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/plugins/controlboard/src/ControlBoardTrajectory.cpp
+++ b/plugins/controlboard/src/ControlBoardTrajectory.cpp
@@ -202,11 +202,11 @@ bool MinJerkTrajectoryGenerator::initTrajectory(double current_pos,
                                                 double final_pos,
                                                 double speed,
                                                 double acceleration,
-                                                double controller_period)
+                                                std::chrono::milliseconds controller_period)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    m_controllerPeriod = controller_period * 1000;
+    m_controllerPeriodMilliseconds = controller_period.count();
     double speedf = fabs(speed);
     double dx0 = 0;
     m_computed_reference = current_pos;
@@ -230,7 +230,7 @@ bool MinJerkTrajectoryGenerator::initTrajectory(double current_pos,
     // double step = (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod *
     // _T_controller;
 
-    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / m_controllerPeriod;
+    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / m_controllerPeriodMilliseconds;
     m_dx0 = m_dx0 * m_tf;
 
     dx0 = m_dx0;
@@ -381,11 +381,11 @@ bool ConstSpeedTrajectoryGenerator::initTrajectory(double current_pos,
                                                    double final_pos,
                                                    double speed,
                                                    double acceleration,
-                                                   double controller_period)
+                                                   std::chrono::milliseconds controller_period)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    m_controllerPeriod = controller_period * 1000.0;
+    m_controllerPeriodMilliseconds = controller_period.count();
     m_x0 = current_pos;
     m_xf = final_pos;
     if (m_xf > m_joint_max)
@@ -418,10 +418,10 @@ double ConstSpeedTrajectoryGenerator::p_computeTrajectoryStep()
 
     if (m_xf > m_computed_reference)
     {
-        step = +(m_speed / 1000.0) * m_controllerPeriod; //* _T_controller;
+        step = +(m_speed / 1000.0) * m_controllerPeriodMilliseconds; //* _T_controller;
     } else
     {
-        step = -(m_speed / 1000.0) * m_controllerPeriod; //* _T_controller;
+        step = -(m_speed / 1000.0) * m_controllerPeriodMilliseconds; //* _T_controller;
     }
 
     if (error_abs < fabs(step))
@@ -449,7 +449,7 @@ double ConstSpeedTrajectoryGenerator::computeTrajectory()
 
 double ConstSpeedTrajectoryGenerator::p_computeTrajectory()
 {
-    double step = (m_speed / 1000.0) * m_controllerPeriod; //* _T_controller;
+    double step = (m_speed / 1000.0) * m_controllerPeriodMilliseconds; //* _T_controller;
     double error_abs = fabs(m_computed_reference - m_xf);
 
     if (error_abs)
@@ -490,7 +490,7 @@ bool TrapezoidalSpeedTrajectoryGenerator::initTrajectory(double current_pos,
                                                          double final_pos,
                                                          double speed,
                                                          double acceleration,
-                                                         double controller_period)
+                                                         std::chrono::milliseconds controller_period)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -536,7 +536,7 @@ bool TrapezoidalSpeedTrajectoryGenerator::initTrajectory(double current_pos,
     }
 
     m_computed_reference = current_pos;
-    m_controllerPeriod = controller_period * 1000.0; // milliseconds
+    m_controllerPeriodMilliseconds = controller_period.count();
     m_tick = 0;
     m_trajectory_complete = false;
 
@@ -571,7 +571,7 @@ double TrapezoidalSpeedTrajectoryGenerator::p_computeTrajectoryStep()
         return 0;
     }
 
-    double period = m_controllerPeriod / 1000.0; // in seconds
+    double period = m_controllerPeriodMilliseconds / 1000.0; // in seconds
     double instant = m_tick * period; // current time since start (in seconds)
     double step = 0;
 

--- a/plugins/controlboard/src/ControlBoardTrajectory.cpp
+++ b/plugins/controlboard/src/ControlBoardTrajectory.cpp
@@ -1,0 +1,614 @@
+#include "../include/ControlBoardTrajectory.hh"
+
+#include <gz/physics/GetEntities.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/Types.hh>
+#include <gz/sim/World.hh>
+
+#include <yarp/os/Time.h>
+#include <yarp/sig/Image.h>
+
+namespace yarp
+{
+namespace dev
+{
+namespace gzyarp
+{
+
+void Watchdog::reset()
+{
+    m_lastUpdate = yarp::os::Time::now();
+}
+
+bool Watchdog::isExpired()
+{
+    if (m_duration < 0)
+        return false;
+    if ((yarp::os::Time::now() - m_lastUpdate) > m_duration)
+        return true;
+    return false;
+}
+
+Watchdog::Watchdog(double expireTime)
+{
+    m_duration = expireTime;
+    m_lastUpdate = yarp::os::Time::now();
+}
+
+void Watchdog::modifyDuration(double expireTime)
+{
+    m_duration = expireTime;
+}
+
+double Watchdog::getDuration()
+{
+    return m_duration;
+}
+
+RampFilter::RampFilter()
+{
+    m_final_reference = 0;
+    m_current_value = 0;
+    m_step = 0;
+}
+
+void RampFilter::setReference(double ref, double step)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_final_reference = ref;
+    m_step = step;
+}
+
+void RampFilter::stop()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_final_reference = 0.0;
+    m_current_value = 0.0;
+    m_step = 0.0;
+}
+
+void RampFilter::update()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    double tmp = 0;
+    double error_abs = fabs(m_final_reference - m_current_value);
+
+    if (m_final_reference > m_current_value)
+    {
+        tmp = +(m_step / 1000.0) * 1.0; //* m_controllerPeriod* _T_controller;
+    } else
+    {
+        tmp = -(m_step / 1000.0) * 1.0; //* m_controllerPeriod*_T_controller;
+    }
+
+    if (error_abs < fabs(tmp))
+    {
+        tmp = (m_final_reference - m_current_value);
+    }
+
+    m_current_value = m_current_value + tmp;
+}
+
+double RampFilter::getCurrentValue()
+{
+    return m_current_value;
+}
+
+//------------------------------------------------------------------------------------------------------------------
+// TrajectoryGenerator
+//------------------------------------------------------------------------------------------------------------------
+
+TrajectoryGenerator::TrajectoryGenerator(gz::sim::Model* model)
+    : m_robot(model)
+    , m_trajectory_complete(true)
+    , m_speed(0)
+    , m_acceleration(0)
+    , m_joint_min(0)
+    , m_joint_max(0)
+{
+}
+
+TrajectoryGenerator::~TrajectoryGenerator()
+{
+}
+
+bool TrajectoryGenerator::isMotionDone()
+{
+    return m_trajectory_complete;
+}
+
+bool TrajectoryGenerator::setLimits(double min, double max)
+{
+    m_joint_min = min;
+    m_joint_max = max;
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------
+// MinJerkTrajectoryGenerator
+//------------------------------------------------------------------------------------------------------------------
+
+MinJerkTrajectoryGenerator::MinJerkTrajectoryGenerator(gz::sim::Model* model)
+    : TrajectoryGenerator(model)
+{
+}
+
+MinJerkTrajectoryGenerator::~MinJerkTrajectoryGenerator()
+{
+}
+
+double MinJerkTrajectoryGenerator::p_compute_p5f(double t)
+{
+    double accum = m_dx0 * t;
+    double tmp = t * t * t;
+    accum = accum + tmp * m_trajectory_coeff_c1; //(10*xfx0 - 6*dx0);
+    tmp *= t;
+    accum = accum - tmp * m_trajectory_coeff_c2; //(15*xfx0 - 8*dx0);
+    tmp *= t;
+    accum = accum + tmp * m_trajectory_coeff_c3; //(6*xfx0 - 3*dx0);
+    return accum;
+}
+
+double MinJerkTrajectoryGenerator::p_compute_p5f_vel(double t)
+{
+    double accum = -2 * m_dx0 * t - m_dx0;
+    accum = accum + (30 * m_x0 + 15 * m_dx0 - 30 * m_xf) * (t * t);
+    accum = -accum / m_tf * (t - 1) * (t - 1);
+    return accum;
+}
+
+double MinJerkTrajectoryGenerator::p_compute_current_vel()
+{
+    double a;
+
+    //(10 * (t/T)^3 - 15 * (t/T)^4 + 6 * (t/T)^5) * (x0-xf) + x0
+    if (m_trajectory_complete)
+        return 0;
+    if (m_cur_t == 0)
+    {
+        return 0;
+    } else if (m_cur_t < 1.0 - m_step)
+    {
+        // calculate the velocity
+        a = p_compute_p5f_vel(m_cur_t);
+        return a;
+    }
+    return 0;
+}
+
+bool MinJerkTrajectoryGenerator::p_abortTrajectory(double limit)
+{
+    if (!m_trajectory_complete)
+    {
+        m_trajectory_complete = true;
+        m_cur_t = 0;
+        m_cur_step = 0;
+        m_xf = limit;
+    } else
+    {
+        m_cur_t = 0;
+        m_cur_step = 0;
+        m_xf = limit;
+    }
+    return true;
+}
+
+bool MinJerkTrajectoryGenerator::abortTrajectory(double limit)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    bool ret = p_abortTrajectory(limit);
+    return ret;
+}
+
+bool MinJerkTrajectoryGenerator::initTrajectory(double current_pos,
+                                                double final_pos,
+                                                double speed,
+                                                double acceleration,
+                                                double controller_period)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    m_controllerPeriod = controller_period * 1000;
+    double speedf = fabs(speed);
+    double dx0 = 0;
+    m_computed_reference = current_pos;
+
+    if (speed <= 0)
+    {
+        return false;
+    }
+
+    m_dx0 = p_compute_current_vel();
+    m_x0 = current_pos;
+    m_prev_a = current_pos;
+    m_xf = final_pos;
+    if (m_xf > m_joint_max)
+        m_xf = m_joint_max;
+    else if (m_xf < m_joint_min)
+        m_xf = m_joint_min;
+    m_speed = speed;
+    m_acceleration = acceleration; // unused
+
+    // double step = (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod *
+    // _T_controller;
+
+    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / m_controllerPeriod;
+    m_dx0 = m_dx0 * m_tf;
+
+    dx0 = m_dx0;
+    m_trajectory_coeff_c1 = (10 * (m_xf - m_x0) - 6 * dx0);
+    m_trajectory_coeff_c2 = (15 * (m_xf - m_x0) - 8 * dx0);
+    m_trajectory_coeff_c3 = (6 * (m_xf - m_x0) - 3 * dx0);
+
+    if (m_tf < 1 || m_tf == 0)
+    {
+        p_abortTrajectory(final_pos);
+        m_step = 0;
+        return false;
+    } else
+    {
+        m_step = 1 / m_tf;
+    }
+    m_cur_t = 0;
+    m_cur_step = 0;
+    m_trajectory_complete = false;
+
+    return true;
+}
+
+double MinJerkTrajectoryGenerator::p_computeTrajectoryStep()
+{
+    double target = 0;
+    double delta_target = 0;
+
+    // (10 * (t/T)^3 - 15 * (t/T)^4 + 6 * (t/T)^5) * (x0-xf) + x0
+    if (m_trajectory_complete)
+    {
+        target = m_xf;
+        delta_target = target - m_prev_a;
+        m_prev_a = target;
+        // yCDebug(GAZEBOCONTROLBOARD)<<"mdone" << target;
+        return delta_target;
+    }
+
+    if (m_cur_t == 0)
+    {
+        m_cur_t += m_step;
+        m_cur_step++;
+
+        target = m_x0;
+        delta_target = target - m_prev_a;
+        m_prev_a = target;
+        // yCDebug(GAZEBOCONTROLBOARD)<<"first" ;
+        return delta_target;
+    } else if (m_cur_t < 1.0 - m_step)
+    {
+        // calculate the power factors
+        target = p_compute_p5f(m_cur_t);
+        target += m_x0;
+
+        // time
+        m_cur_t += m_step;
+        m_cur_step++;
+
+        delta_target = target - m_prev_a;
+        m_prev_a = target;
+        // yCDebug(GAZEBOCONTROLBOARD)<< delta_target;
+        return delta_target;
+    }
+
+    // yCDebug(GAZEBOCONTROLBOARD)<<"last";
+    m_trajectory_complete = true;
+    target = m_xf;
+
+    // position reached, so step is zero
+    return 0.0;
+}
+
+double MinJerkTrajectoryGenerator::computeTrajectoryStep()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    double ret = p_computeTrajectoryStep();
+    return ret;
+}
+
+double MinJerkTrajectoryGenerator::p_computeTrajectory()
+{
+    double target = 0;
+
+    // (10 * (t/T)^3 - 15 * (t/T)^4 + 6 * (t/T)^5) * (x0-xf) + x0
+    if (m_trajectory_complete)
+    {
+        target = m_xf;
+        m_prev_a = target;
+        // yCDebug(GAZEBOCONTROLBOARD)<<"mdone" << target;
+        return target;
+    }
+
+    if (m_cur_t == 0)
+    {
+        m_cur_t += m_step;
+        m_cur_step++;
+
+        target = m_x0;
+        m_prev_a = target;
+        // yCDebug(GAZEBOCONTROLBOARD)<<"first" ;
+        return target;
+    } else if (m_cur_t < 1.0 - m_step)
+    {
+        // calculate the power factors
+        target = p_compute_p5f(m_cur_t);
+        target += m_x0;
+
+        // time
+        m_cur_t += m_step;
+        m_cur_step++;
+
+        m_prev_a = target;
+        // yCDebug(GAZEBOCONTROLBOARD)<< target;
+        return target;
+    }
+
+    // yCDebug(GAZEBOCONTROLBOARD)<<"last";
+    m_trajectory_complete = true;
+    target = m_xf;
+    return target;
+}
+
+double MinJerkTrajectoryGenerator::computeTrajectory()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    double ret = p_computeTrajectory();
+    return ret;
+}
+
+TrajectoryType MinJerkTrajectoryGenerator::getTrajectoryType()
+{
+    return TRAJECTORY_TYPE_MIN_JERK;
+}
+
+//------------------------------------------------------------------------------------------------------------------
+// ConstSpeedTrajectoryGenerator
+//------------------------------------------------------------------------------------------------------------------
+
+ConstSpeedTrajectoryGenerator::ConstSpeedTrajectoryGenerator(gz::sim::Model* model)
+    : TrajectoryGenerator(model)
+{
+}
+
+ConstSpeedTrajectoryGenerator::~ConstSpeedTrajectoryGenerator()
+{
+}
+
+bool ConstSpeedTrajectoryGenerator::initTrajectory(double current_pos,
+                                                   double final_pos,
+                                                   double speed,
+                                                   double acceleration,
+                                                   double controller_period)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    m_controllerPeriod = controller_period * 1000.0;
+    m_x0 = current_pos;
+    m_xf = final_pos;
+    if (m_xf > m_joint_max)
+        m_xf = m_joint_max;
+    else if (m_xf < m_joint_min)
+        m_xf = m_joint_min;
+    m_speed = speed;
+    m_acceleration = acceleration; // unused
+    m_computed_reference = m_x0;
+    return true;
+}
+
+bool ConstSpeedTrajectoryGenerator::p_abortTrajectory(double limit)
+{
+    // to be implemented
+    return true;
+}
+
+bool ConstSpeedTrajectoryGenerator::abortTrajectory(double limit)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    bool ret = p_abortTrajectory(limit);
+    return ret;
+}
+
+double ConstSpeedTrajectoryGenerator::p_computeTrajectoryStep()
+{
+    double step = 0;
+    double error_abs = fabs(m_xf - m_computed_reference);
+
+    if (m_xf > m_computed_reference)
+    {
+        step = +(m_speed / 1000.0) * m_controllerPeriod; //* _T_controller;
+    } else
+    {
+        step = -(m_speed / 1000.0) * m_controllerPeriod; //* _T_controller;
+    }
+
+    if (error_abs < fabs(step))
+    {
+        step = (m_xf - m_computed_reference);
+    }
+
+    // yCDebug(GAZEBOCONTROLBOARD) << step;
+    return step;
+}
+
+double ConstSpeedTrajectoryGenerator::computeTrajectoryStep()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    double ret = p_computeTrajectoryStep();
+    return ret;
+}
+
+double ConstSpeedTrajectoryGenerator::computeTrajectory()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    double ret = p_computeTrajectory();
+    return ret;
+}
+
+double ConstSpeedTrajectoryGenerator::p_computeTrajectory()
+{
+    double step = (m_speed / 1000.0) * m_controllerPeriod; //* _T_controller;
+    double error_abs = fabs(m_computed_reference - m_xf);
+
+    if (error_abs)
+    {
+        m_computed_reference += p_computeTrajectoryStep();
+        if (error_abs < step)
+        {
+            m_trajectory_complete = true;
+        } else
+        {
+            m_trajectory_complete = false;
+        }
+    }
+
+    // yCDebug(GAZEBOCONTROLBOARD) << m_computed_reference;
+    return m_computed_reference;
+}
+
+TrajectoryType ConstSpeedTrajectoryGenerator::getTrajectoryType()
+{
+    return TRAJECTORY_TYPE_CONST_SPEED;
+}
+
+//------------------------------------------------------------------------------------------------------------------
+// TrapezoidalSpeedTrajectoryGenerator
+//------------------------------------------------------------------------------------------------------------------
+
+TrapezoidalSpeedTrajectoryGenerator::TrapezoidalSpeedTrajectoryGenerator(gz::sim::Model* model)
+    : TrajectoryGenerator(model)
+    , m_computed_reference_velocity(0.0)
+{
+}
+
+TrapezoidalSpeedTrajectoryGenerator::~TrapezoidalSpeedTrajectoryGenerator()
+{
+}
+
+bool TrapezoidalSpeedTrajectoryGenerator::initTrajectory(double current_pos,
+                                                         double final_pos,
+                                                         double speed,
+                                                         double acceleration,
+                                                         double controller_period)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (speed <= 0.0 || acceleration <= 0.0)
+    {
+        return false;
+    }
+
+    m_x0 = current_pos;
+    m_xf = final_pos;
+    m_v0 = m_computed_reference_velocity; // last computed velocity from previous trajectory
+
+    if (m_xf > m_joint_max)
+        m_xf = m_joint_max;
+    else if (m_xf < m_joint_min)
+        m_xf = m_joint_min;
+
+    double sign = (m_xf >= m_x0) ? 1.0 : -1.0;
+    m_speed = sign * speed;
+    m_acceleration = sign * acceleration;
+
+    // hypothetic distance traveled using a double-ramp (i.e. triangular) trajectory that reaches
+    // m_speed
+    double deltaTriMax = 0.5 * (2 * m_speed * m_speed - m_v0 * m_v0) / m_acceleration;
+    double deltaTotal = m_xf - m_x0;
+
+    if (std::abs(deltaTotal) > std::abs(deltaTriMax))
+    {
+        // trapezoidal profile
+        double deltaRamp1 = 0.5 * (m_speed * m_speed - m_v0 * m_v0) / m_acceleration;
+        double deltaRamp2 = 0.5 * m_speed * m_speed / m_acceleration;
+        m_ta = (m_speed - m_v0) / m_acceleration;
+        m_tb = m_ta + (deltaTotal - deltaRamp1 - deltaRamp2) / m_speed;
+        m_tf = m_tb + (m_speed / m_acceleration);
+    } else
+    {
+        // triangular profile
+        double peakVelocity
+            = sign * std::sqrt(0.5 * (2 * m_acceleration * deltaTotal + m_v0 * m_v0));
+        m_ta = (peakVelocity - m_v0) / m_acceleration;
+        m_tb = m_ta;
+        m_tf = m_ta + (peakVelocity / m_acceleration);
+    }
+
+    m_computed_reference = current_pos;
+    m_controllerPeriod = controller_period * 1000.0; // milliseconds
+    m_tick = 0;
+    m_trajectory_complete = false;
+
+    return true;
+}
+
+bool TrapezoidalSpeedTrajectoryGenerator::abortTrajectory(double limit)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_trajectory_complete = true;
+    m_computed_reference_velocity = 0.0;
+    return true;
+}
+
+double TrapezoidalSpeedTrajectoryGenerator::computeTrajectory()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_computed_reference += p_computeTrajectoryStep();
+    return m_computed_reference;
+}
+
+double TrapezoidalSpeedTrajectoryGenerator::computeTrajectoryStep()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return p_computeTrajectoryStep();
+}
+
+double TrapezoidalSpeedTrajectoryGenerator::p_computeTrajectoryStep()
+{
+    if (m_trajectory_complete)
+    {
+        return 0;
+    }
+
+    double period = m_controllerPeriod / 1000.0; // in seconds
+    double instant = m_tick * period; // current time since start (in seconds)
+    double step = 0;
+
+    if (instant <= m_ta) // first ramp
+    {
+        step = 0.5 * m_acceleration * period * period * (2 * m_tick + 1) + m_v0 * period;
+        m_computed_reference_velocity = m_acceleration * instant + m_v0;
+    } else if (instant > m_tb) // second ramp
+    {
+        step = m_acceleration * (m_tf * period - 0.5 * period * period * (2 * m_tick + 1));
+        m_computed_reference_velocity = m_acceleration * (m_tf - instant);
+    } else // constant speed interval between ramps (if any)
+    {
+        step = m_speed * period;
+        m_computed_reference_velocity = m_speed;
+    }
+
+    if (std::abs(step) >= std::abs(m_xf - m_computed_reference) || instant > m_tf)
+    {
+        step = m_xf - m_computed_reference;
+        m_trajectory_complete = true;
+        m_computed_reference_velocity = 0.0;
+    }
+
+    m_tick++;
+    return step;
+}
+
+TrajectoryType TrapezoidalSpeedTrajectoryGenerator::getTrajectoryType()
+{
+    return TRAJECTORY_TYPE_TRAP_SPEED;
+}
+
+} // namespace gzyarp
+} // namespace dev
+} // namespace yarp

--- a/plugins/controlboard/src/ControlBoardTrajectory.cpp
+++ b/plugins/controlboard/src/ControlBoardTrajectory.cpp
@@ -98,9 +98,8 @@ double RampFilter::getCurrentValue()
 // TrajectoryGenerator
 //------------------------------------------------------------------------------------------------------------------
 
-TrajectoryGenerator::TrajectoryGenerator(gz::sim::Model* model)
-    : m_robot(model)
-    , m_trajectory_complete(true)
+TrajectoryGenerator::TrajectoryGenerator()
+    : m_trajectory_complete(true)
     , m_speed(0)
     , m_acceleration(0)
     , m_joint_min(0)
@@ -128,8 +127,7 @@ bool TrajectoryGenerator::setLimits(double min, double max)
 // MinJerkTrajectoryGenerator
 //------------------------------------------------------------------------------------------------------------------
 
-MinJerkTrajectoryGenerator::MinJerkTrajectoryGenerator(gz::sim::Model* model)
-    : TrajectoryGenerator(model)
+MinJerkTrajectoryGenerator::MinJerkTrajectoryGenerator()
 {
 }
 
@@ -364,15 +362,14 @@ double MinJerkTrajectoryGenerator::computeTrajectory()
 
 TrajectoryType MinJerkTrajectoryGenerator::getTrajectoryType()
 {
-    return TRAJECTORY_TYPE_MIN_JERK;
+    return TrajectoryType::TRAJECTORY_TYPE_MIN_JERK;
 }
 
 //------------------------------------------------------------------------------------------------------------------
 // ConstSpeedTrajectoryGenerator
 //------------------------------------------------------------------------------------------------------------------
 
-ConstSpeedTrajectoryGenerator::ConstSpeedTrajectoryGenerator(gz::sim::Model* model)
-    : TrajectoryGenerator(model)
+ConstSpeedTrajectoryGenerator::ConstSpeedTrajectoryGenerator()
 {
 }
 
@@ -473,16 +470,15 @@ double ConstSpeedTrajectoryGenerator::p_computeTrajectory()
 
 TrajectoryType ConstSpeedTrajectoryGenerator::getTrajectoryType()
 {
-    return TRAJECTORY_TYPE_CONST_SPEED;
+    return TrajectoryType::TRAJECTORY_TYPE_CONST_SPEED;
 }
 
 //------------------------------------------------------------------------------------------------------------------
 // TrapezoidalSpeedTrajectoryGenerator
 //------------------------------------------------------------------------------------------------------------------
 
-TrapezoidalSpeedTrajectoryGenerator::TrapezoidalSpeedTrajectoryGenerator(gz::sim::Model* model)
-    : TrajectoryGenerator(model)
-    , m_computed_reference_velocity(0.0)
+TrapezoidalSpeedTrajectoryGenerator::TrapezoidalSpeedTrajectoryGenerator()
+    : m_computed_reference_velocity(0.0)
 {
 }
 
@@ -606,7 +602,7 @@ double TrapezoidalSpeedTrajectoryGenerator::p_computeTrajectoryStep()
 
 TrajectoryType TrapezoidalSpeedTrajectoryGenerator::getTrajectoryType()
 {
-    return TRAJECTORY_TYPE_TRAP_SPEED;
+    return TrajectoryType::TRAJECTORY_TYPE_TRAP_SPEED;
 }
 
 } // namespace gzyarp

--- a/tests/controlboard/CMakeLists.txt
+++ b/tests/controlboard/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(ControlBoardTorqueControlTest ControlBoardTorqueControlTest.cc)
 add_executable(ControlBoardPositionDirectControlTest ControlBoardPositionDirectControlTest.cc)
+add_executable(ControlBoardPositionControlTest ControlBoardPositionControlTest.cc)
 
 target_link_libraries(ControlBoardTorqueControlTest
     PRIVATE gtest_main
@@ -23,16 +24,34 @@ target_link_libraries(ControlBoardPositionDirectControlTest
         gz-sim-yarp-handler
 )
 
+target_link_libraries(ControlBoardPositionControlTest
+    PRIVATE gtest_main
+    PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+    PRIVATE gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+    PRIVATE
+        YARP::YARP_dev
+        YARP::YARP_os
+        YARP::YARP_init
+        gz-sim-yarp-handler
+)
+
 add_test(NAME ControlBoardTorqueControlTest
          COMMAND ControlBoardTorqueControlTest)
 
 add_test(NAME ControlBoardPositionDirectControlTest
          COMMAND ControlBoardPositionDirectControlTest)
 
+add_test(NAME ControlBoardPositionControlTest
+         COMMAND ControlBoardPositionControlTest)
+
 set(_env_vars)
 list(APPEND _env_vars "GZ_SIM_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:gz-sim-yarp-controlboard-system>")
 
 set_tests_properties(ControlBoardTorqueControlTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
 set_tests_properties(ControlBoardPositionDirectControlTest PROPERTIES
+  ENVIRONMENT "${_env_vars}")
+
+set_tests_properties(ControlBoardPositionControlTest PROPERTIES
   ENVIRONMENT "${_env_vars}")

--- a/tests/controlboard/ControlBoardPositionControlTest.cc
+++ b/tests/controlboard/ControlBoardPositionControlTest.cc
@@ -1,0 +1,145 @@
+#include "../../libraries/common/Common.hh"
+#include "../../libraries/singleton-devices/Handler.hh"
+#include <cmath>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <gz/sim/Joint.hh>
+#include <gz/sim/Link.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/TestFixture.hh>
+#include <gz/sim/Util.hh>
+#include <gz/sim/World.hh>
+#include <gz/sim/components/JointForceCmd.hh>
+#include <iostream>
+#include <string>
+#include <yarp/dev/IControlMode.h>
+#include <yarp/dev/IEncoders.h>
+#include <yarp/dev/IPositionControl.h>
+#include <yarp/dev/IPositionDirect.h>
+#include <yarp/dev/ITorqueControl.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Network.h>
+
+class ControlBoardPositionFixture : public testing::Test
+{
+protected:
+    // void SetUp() override
+    ControlBoardPositionFixture()
+        : testFixture{"../../../tests/controlboard/pendulum_joint_relative_to_parent_link.sdf"}
+    {
+        gz::common::Console::SetVerbosity(4);
+
+        testFixture.
+            // Use configure callback to get values at startup
+            OnConfigure([&](const gz::sim::Entity& _worldEntity,
+                            const std::shared_ptr<const sdf::Element>& /*_sdf*/,
+                            gz::sim::EntityComponentManager& _ecm,
+                            gz::sim::EventManager& /*_eventMgr*/) {
+                std::cerr << "Configuring test" << std::endl;
+
+                gz::sim::World world(_worldEntity);
+
+                // Get model
+                auto modelEntity = world.ModelByName(_ecm, "single_pendulum");
+                modelEntity = world.ModelByName(_ecm, "single_pendulum");
+                EXPECT_NE(gz::sim::kNullEntity, modelEntity);
+                model = gz::sim::Model(modelEntity);
+
+                driver = gzyarp::Handler::getHandler()->getDevice(deviceScopedName);
+                ASSERT_TRUE(driver != nullptr);
+                iPositionControl = nullptr;
+                ASSERT_TRUE(driver->view(iPositionControl));
+                iControlMode = nullptr;
+                ASSERT_TRUE(driver->view(iControlMode));
+                iEncoders = nullptr;
+                ASSERT_TRUE(driver->view(iEncoders));
+
+                // Get joint
+                auto jointEntity = model.JointByName(_ecm, "upper_joint");
+                EXPECT_NE(gz::sim::kNullEntity, jointEntity);
+                joint = gz::sim::Joint(jointEntity);
+
+                // Set joint in torque control mode
+                ASSERT_TRUE(iControlMode->setControlMode(0, VOCAB_CM_POSITION));
+
+                // Print number of joint configured
+                int nJointsConfigured{};
+                ASSERT_TRUE(iPositionControl->getAxes(&nJointsConfigured));
+                std::cerr << "Number of joints configured: " << nJointsConfigured << std::endl;
+
+                configured = true;
+                std::cerr << "Test configured" << std::endl;
+            });
+    }
+
+    // Get SDF model name from test parameter
+    gz::sim::TestFixture testFixture;
+    std::string deviceScopedName = "model/single_pendulum/controlboard_plugin_device";
+    double linkMass{1};
+    double linkLength{1.0};
+    double linkInertiaAtLinkEnd{0.3352}; // Computed with parallel axis theorem
+    int plannedIterations{1000};
+    int iterations{0};
+    std::vector<double> trackingErrors{};
+    double acceptedTolerance{5e-2};
+    bool configured{false};
+    gz::math::Vector3d gravity;
+    gz::sim::Entity modelEntity;
+    gz::sim::Model model;
+    gz::sim::Joint joint;
+    yarp::dev::PolyDriver* driver;
+    yarp::dev::IPositionControl* iPositionControl = nullptr;
+    yarp::dev::IControlMode* iControlMode = nullptr;
+    yarp::dev::IEncoders* iEncoders = nullptr;
+};
+
+TEST_F(ControlBoardPositionFixture, CheckPositionTrackingWithTrajectoryGenerationUsingPendulumModel)
+{
+    auto refPosition{90.0};
+    bool motionDone{false};
+    double jointPosition, jointPosError;
+
+    testFixture
+        .OnPostUpdate(
+            [&](const gz::sim::UpdateInfo& _info, const gz::sim::EntityComponentManager& _ecm) {
+                // std::cerr << "========== Iteration: " << iterations << std::endl;
+
+                iEncoders->getEncoder(0, &jointPosition);
+                iPositionControl->checkMotionDone(0, &motionDone);
+
+                // std::cerr << "ref position: " << refTrajectory[iterations] << std::endl;
+                // std::cerr << "joint position: " << jointPosition << std::endl;
+
+                iterations++;
+            })
+        .
+        // The moment we finalize, the configure callback is called
+        Finalize();
+
+    int modeSet{};
+    iControlMode->getControlMode(0, &modeSet);
+    ASSERT_TRUE(modeSet == VOCAB_CM_POSITION);
+
+    // Set reference position
+    iPositionControl->positionMove(0, refPosition);
+
+    // Setup simulation server, this will call the post-update callbacks.
+    // It also calls pre-update and update callbacks if those are being used.
+    while (!motionDone)
+    {
+        std::cerr << "Running server" << std::endl;
+        testFixture.Server()->Run(true, plannedIterations, false);
+        jointPosError = abs(refPosition - jointPosition);
+        std::cerr << "Joint position error: " << jointPosError << std::endl;
+    }
+
+    // Final assertions
+    ASSERT_TRUE(configured);
+    ASSERT_TRUE(motionDone);
+
+    // Verify that the final error is within the accepted tolerance
+    std::cerr << "Final tracking error: " << jointPosError << std::endl;
+    ASSERT_LT(jointPosError, acceptedTolerance);
+}

--- a/tests/controlboard/conf/gazebo_controlboard.ini
+++ b/tests/controlboard/conf/gazebo_controlboard.ini
@@ -7,7 +7,7 @@ jointNames upper_joint
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            1000.0
+kp            3000.0
 kd            2.0
 ki            0.1
 maxInt        99999

--- a/tests/controlboard/pendulum_joint_relative_to_child_link.sdf
+++ b/tests/controlboard/pendulum_joint_relative_to_child_link.sdf
@@ -143,7 +143,7 @@
                 <yarpConfigurationFile>
                     ../../../tests/controlboard/conf/gazebo_controlboard.ini
                 </yarpConfigurationFile>
-                <initialConfiguration>0.0 0.0</initialConfiguration>
+                <initialConfiguration>0.0</initialConfiguration>
             </plugin>
         </model>
     </world>

--- a/tests/controlboard/pendulum_joint_relative_to_parent_link.sdf
+++ b/tests/controlboard/pendulum_joint_relative_to_parent_link.sdf
@@ -139,7 +139,7 @@
                 <yarpConfigurationFile>
                     ../../../tests/controlboard/conf/gazebo_controlboard.ini
                 </yarpConfigurationFile>
-                <initialConfiguration>0.0 0.0</initialConfiguration>
+                <initialConfiguration>0.0</initialConfiguration>
             </plugin>
         </model>
     </world>

--- a/tutorial/single_pendulum/conf/gazebo_controlboard.ini
+++ b/tutorial/single_pendulum/conf/gazebo_controlboard.ini
@@ -24,3 +24,13 @@ Pid0 500.0 2.0 0.1 9999 9999 9 9
 [LIMITS]
 jntPosMax 200.0
 jntPosMin -200.0
+
+[TRAJECTORY_GENERATION]
+# Uncomment one of the following lines to select the trajectory generation method
+#trajectory_type constant_speed
+trajectory_type trapezoidal_speed
+#trajectory_type minimum_jerk
+
+# Uncomment the following lines to override the default trajectory generation parameters
+#refSpeed 10.0
+#refAcceleration 10.0

--- a/tutorial/single_pendulum/model.sdf
+++ b/tutorial/single_pendulum/model.sdf
@@ -96,7 +96,7 @@
             <yarpConfigurationFile>
                 conf/gazebo_controlboard.ini
             </yarpConfigurationFile>
-            <initialConfiguration>0.0 0.0</initialConfiguration>
+            <initialConfiguration>0.0</initialConfiguration>
         </plugin>
         <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
             <yarpRobotInterfaceConfigurationFile>


### PR DESCRIPTION
This PR adds to the control board plugin the implementation of [IPositionControl](https://www.yarp.it/git-master/classyarp_1_1dev_1_1IPositionControl.html) 

This control mode uses a trajectory generator to interpolate between subsequent position references, with multiple possible options (at the moment they are trapezoidal velocity profile, minimum jerk trajectory, constant velocity).

Closes #83 