### PR TITLE
Fix timestamp written by clock plugin

### DIFF
--- a/plugins/clock/Clock.cc
+++ b/plugins/clock/Clock.cc
@@ -1,6 +1,8 @@
+#include <chrono>
 #include <gz/plugin/Register.hh>
 #include <gz/sim/System.hh>
 #include <gz/sim/Util.hh>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Log.h>
@@ -58,9 +60,15 @@ public:
             return;
         }
 
+        auto currentTime = _info.simTime;
+        std::chrono::seconds seconds
+            = std::chrono::duration_cast<std::chrono::seconds>(currentTime);
+        std::chrono::nanoseconds nanoseconds = currentTime - seconds;
+
         Bottle& b = m_clockPort.prepare();
         b.clear();
-        b.addInt64(_info.simTime.count());
+        b.addInt32(seconds.count());
+        b.addInt32(nanoseconds.count());
         m_clockPort.write();
     }
 

--- a/tests/clock/ClockTest.cc
+++ b/tests/clock/ClockTest.cc
@@ -4,7 +4,7 @@
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Network.h>
 
-TEST(ClockTest, GetSimTimeAsExpected)
+TEST(ClockTest, GetSimulationTimeFromClockPort)
 {
     // ARRANGE
     yarp::os::NetworkBase::setLocalMode(true);
@@ -12,12 +12,14 @@ TEST(ClockTest, GetSimTimeAsExpected)
     gz::common::Console::SetVerbosity(4);
     // Instantiate test fixture
     gz::sim::TestFixture fixture("../../../tests/clock/model.sdf");
-    const int iterations = 10;
+    const int iterations = 1000;
     const int deltaTns = 1e6; // 1ms
     const int tolerance = 1e6; // 1ms
     yarp::os::BufferedPort<yarp::os::Bottle> p; // Create a port.
     p.open("/tmp_in"); // Give it a name on the network.
     yarp::os::Network::connect("/clock", "/tmp_in"); // connect two ports.
+    int expectedSimTimeSeconds = (iterations - 1) / 1e3;
+    int expectedSimTimeNanoseconds = 0;
 
     // ACT
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);
@@ -25,8 +27,9 @@ TEST(ClockTest, GetSimTimeAsExpected)
 
     // ASSERT
     yarp::os::Bottle* b = p.read();
-    auto simTime = b->get(0).asInt64();
+    auto simTimeSeconds = b->get(0).asInt32();
+    auto simTimeNanoseconds = b->get(1).asInt32();
 
-    ASSERT_NEAR(simTime, (iterations - 1) * deltaTns, tolerance)
-        << "simTime: " << simTime << std::endl;
+    ASSERT_NEAR(simTimeSeconds, expectedSimTimeSeconds, tolerance);
+    ASSERT_NEAR(simTimeNanoseconds, expectedSimTimeNanoseconds, tolerance);
 }


### PR DESCRIPTION
This PR affects the clock plugin.

It fixes the format of the timestamp written on the `/clock` port to be what yarp requires.