### PR TITLE
Add support for loading vector from configuration files with parenthesis

### DIFF
--- a/libraries/common/Common.hh
+++ b/libraries/common/Common.hh
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Value.h>
 namespace gzyarp
 {
 constexpr double pi = 3.1415926535897932384626433;
@@ -24,6 +29,81 @@ inline double convertDegreeGainToRadianGains(double degreeGain)
 inline double convertRadianGainToDegreeGains(double radianGain)
 {
     return radianGain / 180.0 * pi;
+}
+
+template <typename T> inline T readElementFromValue(const yarp::os::Value& value);
+
+template <> inline double readElementFromValue<double>(const yarp::os::Value& value)
+{
+    return value.asFloat64();
+}
+
+template <> inline int readElementFromValue<int>(const yarp::os::Value& value)
+{
+    return value.asInt64();
+}
+
+template <> inline std::string readElementFromValue<std::string>(const yarp::os::Value& value)
+{
+    return value.asString();
+}
+
+template <> inline bool readElementFromValue<bool>(const yarp::os::Value& value)
+{
+    return value.asBool();
+}
+
+/**
+ * Get a vector from a parameter, using both the recommended style:
+ * nameOfList (elem1 elem2 elem3)
+ * or the deprecated (since YARP 3.10):
+ * nameOfList elem1 elem2 elem3
+ *
+ *
+ * \brief Get vector from YARP configuration
+ * \return true if the parsing was successful, false otherwise
+ */
+template <typename T>
+inline bool readVectorFromConfigFile(const yarp::os::Searchable& params,
+                                     const std::string& listName,
+                                     std::vector<T>& outputList)
+{
+    bool vectorPopulated = false;
+    outputList.resize(0);
+    yarp::os::Value& val = params.find(listName);
+    if (!val.isNull() && val.isList())
+    {
+        yarp::os::Bottle* listBot = val.asList();
+        outputList.resize(listBot->size());
+
+        for (size_t i = 0; i < outputList.size(); i++)
+        {
+            outputList[i] = readElementFromValue<T>(listBot->get(i));
+        }
+
+        vectorPopulated = true;
+    } else
+    {
+        // Try to interpreter the list via findGroup
+        yarp::os::Bottle listBottleAndKey = params.findGroup(listName);
+        if (!listBottleAndKey.isNull())
+        {
+            yWarning() << "Parameter " << listName
+                       << " should be a list, but its format is deprecated as parenthesis are "
+                          "missing."
+                       << " Please add parentesis to the list, as documented in "
+                          "https://github.com/robotology/yarp/discussions/3092 .";
+
+            outputList.resize(listBottleAndKey.size() - 1);
+
+            for (size_t i = 0; i < outputList.size(); i++)
+            {
+                outputList[i] = readElementFromValue<T>(listBottleAndKey.get(i + 1));
+            }
+            vectorPopulated = true;
+        }
+    }
+    return vectorPopulated;
 }
 
 } // namespace gzyarp

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -78,11 +78,11 @@ private:
                                                const gz::sim::EntityComponentManager& ecm) const;
     bool initializePIDsForPositionControl();
     bool tryGetGroup(const yarp::os::Bottle& in,
-                     yarp::os::Bottle& out,
+                     std::vector<double>& out,
                      const std::string& key,
                      const std::string& txt,
-                     int size);
-    bool setYarpPIDsParam(const yarp::os::Bottle& pidParamGroup,
+                     int expectedSize);
+    bool setYarpPIDsParam(const std::vector<double>& pidParams,
                           const std::string& paramName,
                           std::vector<yarp::dev::Pid>& yarpPIDs,
                           size_t numberOfJoints);

--- a/tests/commons/conf/controlboard.ini
+++ b/tests/commons/conf/controlboard.ini
@@ -1,25 +1,34 @@
 yarpDeviceName controlboard_plugin_device
-jointNames joint_12
+jointNames (joint_12)
 
 #PIDs:
-# this information is used to set the PID values in simulation for GAZEBO, we need only the first three values
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            3000.0
-kd            2.0
-ki            0.1
-maxInt        99999
-maxOutput     99999
-shift         0.0
-ko            0.0
-stictionUp    0.0
-stictionDwn   0.0
+kp            (3000.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (99999)
+maxOutput     (99999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
-[GAZEBO_VELOCITY_PIDS]
-#Torso
-Pid0 500.0 2.0 0.1 9999 9999 9 9
+[VELOCITY_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+velocityControlImplementationType integrator_and_position_pid
+kp            (500.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
 [LIMITS]
-jntPosMax 200.0
-jntPosMin -200.0
+jntPosMax (200.0)
+jntPosMin (-200.0)

--- a/tests/controlboard/conf/gazebo_controlboard.ini
+++ b/tests/controlboard/conf/gazebo_controlboard.ini
@@ -1,25 +1,34 @@
 yarpDeviceName controlboard_plugin_device
-jointNames upper_joint
+jointNames (upper_joint)
 
 #PIDs:
-# this information is used to set the PID values in simulation for GAZEBO, we need only the first three values
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            3000.0
-kd            2.0
-ki            0.1
-maxInt        99999
-maxOutput     99999
-shift         0.0
-ko            0.0
-stictionUp    0.0
-stictionDwn   0.0
+kp            (3000.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (99999)
+maxOutput     (99999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
-[GAZEBO_VELOCITY_PIDS]
-#Torso
-Pid0 500.0 2.0 0.1 9999 9999 9 9
+[VELOCITY_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+velocityControlImplementationType integrator_and_position_pid
+kp            (500.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
 [LIMITS]
-jntPosMax 200.0
-jntPosMin -200.0
+jntPosMax (200.0)
+jntPosMin (-200.0)

--- a/tests/controlboard/conf/gazebo_controlboard2.ini
+++ b/tests/controlboard/conf/gazebo_controlboard2.ini
@@ -1,25 +1,34 @@
 yarpDeviceName controlboard_plugin_device2
-jointNames lower_joint
+jointNames (lower_joint)
 
 #PIDs:
-# this information is used to set the PID values in simulation for GAZEBO, we need only the first three values
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            3000.0
-kd            2.0
-ki            0.1
-maxInt        99999
-maxOutput     99999
-shift         0.0
-ko            0.0
-stictionUp    0.0
-stictionDwn   0.0
+kp            (3000.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (99999)
+maxOutput     (99999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
-[GAZEBO_VELOCITY_PIDS]
-#Torso
-Pid0 500.0 2.0 0.1 9999 9999 9 9
+[VELOCITY_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+velocityControlImplementationType integrator_and_position_pid
+kp            (500.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
 [LIMITS]
-jntPosMax 200.0
-jntPosMin -200.0
+jntPosMax (200.0)
+jntPosMin (-200.0)

--- a/tests/controlboard/conf/gazebo_controlboard_multiple_joints.ini
+++ b/tests/controlboard/conf/gazebo_controlboard_multiple_joints.ini
@@ -1,24 +1,34 @@
 yarpDeviceName controlboard_plugin_device
-jointNames upper_joint lower_joint
+jointNames (upper_joint lower_joint)
 
 #PIDs:
 # this information is used to set the PID values in simulation for GAZEBO, we need only the first three values
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            3000.0   3000.0
-kd            2.0      2.0
-ki            0.1      0.1
-maxInt        99999    99999
-maxOutput     99999    99999
-shift         0.0      0.0
-ko            0.0      0.0
-stictionUp    0.0      0.0
-stictionDwn   0.0      0.0
+kp            (3000.0   3000.0)
+kd            (2.0      2.0)
+ki            (0.1      0.1)
+maxInt        (99999    99999)
+maxOutput     (99999    99999)
+shift         (0.0      0.0)
+ko            (0.0      0.0)
+stictionUp    (0.0      0.0)
+stictionDwn   (0.0      0.0)
 
-[GAZEBO_VELOCITY_PIDS]
-#Torso
-Pid0 500.0 2.0 0.1 9999 9999 9 9
+[VELOCITY_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+velocityControlImplementationType integrator_and_position_pid
+kp            (500.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
 [LIMITS]
 jntPosMax 200.0 10.0

--- a/tutorial/single_pendulum/conf/gazebo_controlboard.ini
+++ b/tutorial/single_pendulum/conf/gazebo_controlboard.ini
@@ -1,29 +1,38 @@
 disableImplicitNetworkWrapper
 yarpDeviceName controlboard_plugin_device
-jointNames upper_joint
+jointNames (upper_joint)
 
 #PIDs:
-# this information is used to set the PID values in simulation for GAZEBO
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            1000.0
-kd            2.0
-ki            0.1
-maxInt        99999
-maxOutput     99999
-shift         0.0
-ko            0.0
-stictionUp    0.0
-stictionDwn   0.0
+kp            (3000.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (99999)
+maxOutput     (99999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
-[GAZEBO_VELOCITY_PIDS]
-#Torso
-Pid0 500.0 2.0 0.1 9999 9999 9 9
+[VELOCITY_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+velocityControlImplementationType integrator_and_position_pid
+kp            (500.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
 [LIMITS]
-jntPosMax 200.0
-jntPosMin -200.0
+jntPosMax (200.0)
+jntPosMin (-200.0)
 
 [TRAJECTORY_GENERATION]
 # Uncomment one of the following lines to select the trajectory generation method


### PR DESCRIPTION
Closes #138

As discussed in https://github.com/robotology/yarp/discussions/3092, it is recommended for future software that uses YARP to use vectors in configuration files by indicating them with parenthesis, i.e. to refer to them with:

```
nameOfList (elem1 elem2 elem3)
```

instead of:

```
nameOfList elem1 elem2 elem3
```

After this PR, now plugins support both the with-parentheses and without-parenthesis style, printing a warning if the without-parenthesis style is used.