### PR TITLE
Use absolute paths to reference models in unit tests

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -67,14 +67,14 @@ jobs:
     - name: Print used environment
       shell: bash -l {0}
       run: |
-        micromamba list
+        conda list --explicit
         env
 
     - name: Configure
       shell: bash -l {0}
       run: |
         mkdir -p build
-        cd build    
+        cd build
         cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DBUILD_TESTING:BOOL=ON ..
 
@@ -82,15 +82,15 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        cmake --build . --config ${{ matrix.build_type }} 
+        cmake --build . --config ${{ matrix.build_type }}
 
     - name: Test_ubuntu
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build
-        ctest -E "^LaserTest|^CameraTest|^ImuTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} . 
-  
+        ctest -E "^LaserTest|^CameraTest|^ImuTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+
     - name: Test_macos
       if: contains(matrix.os, 'macos')
       shell: bash -l {0}

--- a/tests/camera/CMakeLists.txt
+++ b/tests/camera/CMakeLists.txt
@@ -13,3 +13,5 @@ list(APPEND _env_vars "LIBGL_ALWAYS_SOFTWARE=1")
 
 set_tests_properties(CameraTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
+target_compile_definitions(CameraTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/camera/CameraTest.cc
+++ b/tests/camera/CameraTest.cc
@@ -1,8 +1,19 @@
 #include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <thread>
+
+#include <gz/common/Console.hh>
 #include <gz/sim/TestFixture.hh>
+
 #include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Network.h>
+#include <yarp/os/Property.h>
+#include <yarp/sig/Image.h>
 
 TEST(CameraTest, PluginTest)
 {
@@ -12,7 +23,8 @@ TEST(CameraTest, PluginTest)
     gz::common::Console::SetVerbosity(4);
 
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/camera/model.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
 
     int iterations = 1000;
 
@@ -80,7 +92,8 @@ TEST(CameraTest, HorizontalFlip)
     gz::common::Console::SetVerbosity(4);
 
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/camera/model_hor_flip.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model_hor_flip.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
 
     int iterations = 1000;
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);
@@ -147,7 +160,8 @@ TEST(CameraTest, VerticalFlip)
     gz::common::Console::SetVerbosity(4);
 
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/camera/model_ver_flip.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model_ver_flip.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
 
     int iterations = 1000;
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);
@@ -214,7 +228,8 @@ TEST(CameraTest, HorizontalVerticalFlip)
     gz::common::Console::SetVerbosity(4);
 
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/camera/model_hor_ver_flip.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model_hor_ver_flip.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
 
     int iterations = 1000;
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);

--- a/tests/clock/CMakeLists.txt
+++ b/tests/clock/CMakeLists.txt
@@ -13,3 +13,5 @@ list(APPEND _env_vars "GZ_SIM_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:gz-sim-yarp-c
 
 set_tests_properties(ClockTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
+target_compile_definitions(ClockTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/clock/ClockTest.cc
+++ b/tests/clock/ClockTest.cc
@@ -1,5 +1,12 @@
 #include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <thread>
+
+#include <gz/common/Console.hh>
 #include <gz/sim/TestFixture.hh>
+
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/Network.h>
@@ -11,7 +18,9 @@ TEST(ClockTest, GetSimulationTimeFromClockPort)
     // Maximum verbosity helps with debugging
     gz::common::Console::SetVerbosity(4);
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/clock/model.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
+
     const int iterations = 1000;
     const int deltaTns = 1e6; // 1ms
     const int tolerance = 1e6; // 1ms

--- a/tests/commons/CMakeLists.txt
+++ b/tests/commons/CMakeLists.txt
@@ -69,3 +69,7 @@ set_tests_properties(ConfigurationParsingFromStringTest PROPERTIES
 
 set_tests_properties(ConcurrentInstancesTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
+target_compile_definitions(ConfigurationParsingFromFileTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(ConfigurationParsingFromStringTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(ConcurrentInstancesTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/commons/ConcurrentInstancesTest.cc
+++ b/tests/commons/ConcurrentInstancesTest.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <ostream>
 #include <thread>
@@ -12,10 +13,10 @@ TEST(ConcurrentInstancesTest, StartConcurrentGazeboInstancesOfDifferentModels)
 {
     auto plannedIterations = 1'000;
 
-    gz::sim::TestFixture fixture1("../../../tests/commons/"
-                                  "dummy_sphere.sdf");
-    gz::sim::TestFixture fixture2("../../../tests/commons/"
-                                  "dummy_box.sdf");
+    gz::sim::TestFixture fixture1(
+        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "dummy_sphere.sdf").string());
+    gz::sim::TestFixture fixture2(
+        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "dummy_box.sdf").string());
     gz::common::Console::SetVerbosity(4);
 
     fixture1.Finalize();

--- a/tests/commons/ConfigurationParsingFromFileTest.cc
+++ b/tests/commons/ConfigurationParsingFromFileTest.cc
@@ -9,6 +9,7 @@
 #include <gz/sim/TestFixture.hh>
 #include <sdf/Element.hh>
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -26,13 +27,13 @@ TEST(ConfigurationParsingTest, LoadPluginsWithYarpConfigurationFile)
 {
     using namespace std::chrono_literals;
 
-    std::string modelSdfName = "model_configuration_file.sdf";
-    std::string sdfPath = std::string("../../../tests/commons/") + modelSdfName;
+    auto modelPath
+        = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model_configuration_file.sdf";
+    gz::sim::TestFixture testFixture(modelPath.string());
+
     yarp::os::NetworkBase::setLocalMode(true);
     gz::common::Console::SetVerbosity(4);
     gz::sim::EntityComponentManager* ecm;
-
-    gz::sim::TestFixture testFixture{sdfPath};
 
     testFixture.OnConfigure([&](const gz::sim::Entity& _worldEntity,
                                 const std::shared_ptr<const sdf::Element>& /*_sdf*/,

--- a/tests/commons/ConfigurationParsingFromStringTest.cc
+++ b/tests/commons/ConfigurationParsingFromStringTest.cc
@@ -9,6 +9,7 @@
 #include <gz/sim/TestFixture.hh>
 #include <sdf/Element.hh>
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -23,14 +24,13 @@
 
 TEST(ConfigurationParsingTest, LoadPluginsWithYarpConfigurationString)
 {
-    std::string modelSdfName = "model_configuration_string.sdf";
-    std::string sdfPath = std::string("../../../tests/commons/") + modelSdfName;
+    auto modelPath
+        = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model_configuration_string.sdf";
+    gz::sim::TestFixture testFixture(modelPath.string());
     yarp::os::NetworkBase::setLocalMode(true);
     gz::common::Console::SetVerbosity(4);
 
     gz::sim::EntityComponentManager* ecm;
-
-    gz::sim::TestFixture testFixture{sdfPath};
 
     testFixture.OnConfigure([&](const gz::sim::Entity& _worldEntity,
                                 const std::shared_ptr<const sdf::Element>& /*_sdf*/,

--- a/tests/controlboard/CMakeLists.txt
+++ b/tests/controlboard/CMakeLists.txt
@@ -33,5 +33,8 @@ foreach(TEST ${TESTS})
 
   set_tests_properties(${TEST} PROPERTIES
     ENVIRONMENT "${_env_vars}")
+
+  target_compile_definitions(${TEST} PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+
     
 endforeach()

--- a/tests/controlboard/ControlBoardCommonsTest.cc
+++ b/tests/controlboard/ControlBoardCommonsTest.cc
@@ -4,9 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include <gz/sim/EntityComponentManager.hh>
-#include <gz/sim/EventManager.hh>
-#include <gz/sim/Util.hh>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <sdf/Element.hh>
@@ -15,9 +13,12 @@
 
 #include <gz/common/Console.hh>
 #include <gz/sim/Entity.hh>
+#include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/EventManager.hh>
 #include <gz/sim/Joint.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/TestFixture.hh>
+#include <gz/sim/Util.hh>
 #include <gz/sim/World.hh>
 
 #include <yarp/dev/IControlLimits.h>
@@ -35,9 +36,10 @@ namespace test
 // Checks that the control board can be configured without initial conditions
 TEST(ControlBoardCommonsTest, ConfigureControlBoardWithoutInitialCondition)
 {
-    std::string modelSdfName = "pendulum_no_initial_configuration.sdf";
+    auto modelPath
+        = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "pendulum_no_initial_configuration.sdf";
+    gz::sim::TestFixture testFixture(modelPath.string());
 
-    gz::sim::TestFixture testFixture{"../../../tests/controlboard/" + modelSdfName};
     gz::common::Console::SetVerbosity(4);
 
     testFixture.Finalize();
@@ -46,9 +48,10 @@ TEST(ControlBoardCommonsTest, ConfigureControlBoardWithoutInitialCondition)
 // Checks that the control board can be configured without initial conditions
 TEST(ControlBoardCommonsTest, ConfigureControlBoardWithInitialCondition)
 {
-    std::string modelSdfName = "pendulum_with_initial_configuration.sdf";
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR)
+                     / "pendulum_with_initial_configuration.sdf";
+    gz::sim::TestFixture testFixture(modelPath.string());
 
-    gz::sim::TestFixture testFixture{"../../../tests/controlboard/" + modelSdfName};
     gz::common::Console::SetVerbosity(4);
 
     testFixture.Finalize();
@@ -57,15 +60,15 @@ TEST(ControlBoardCommonsTest, ConfigureControlBoardWithInitialCondition)
 // Check that multiple control board can be congfigured for the same robot model
 TEST(ControlBoardCommonsTest, ConfigureMultipleControlBoards)
 {
-    std::string modelSdfName = "coupled_pendulum_two_controlboards.sdf";
-    std::string sdfPath = std::string("../../../tests/controlboard/") + modelSdfName;
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR)
+                     / "coupled_pendulum_two_controlboards.sdf";
+    gz::sim::TestFixture testFixture(modelPath.string());
 
     bool configured = false;
     std::vector<std::string> deviceIds;
     std::vector<yarp::dev::gzyarp::ControlBoardDriver*> controlBoards;
 
     gz::common::Console::SetVerbosity(4);
-    gz::sim::TestFixture testFixture{sdfPath};
 
     testFixture.OnConfigure([&](const gz::sim::Entity& _worldEntity,
                                 const std::shared_ptr<const sdf::Element>& /*_sdf*/,
@@ -102,15 +105,16 @@ TEST(ControlBoardCommonsTest, ConfigureMultipleControlBoards)
 // Check that joint position limits are read correctly from yarp configuration
 TEST(ControlBoardCommonsTest, JointPositionLimitsForMultipleJoints)
 {
-    std::string modelSdfName = "coupled_pendulum_two_joints_single_controlboard.sdf";
-    std::string sdfPath = std::string("../../../tests/controlboard/") + modelSdfName;
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR)
+                     / "coupled_pendulum_two_joints_single_controlboard.sdf";
+    gz::sim::TestFixture testFixture(modelPath.string());
+
     std::string deviceScopedName = "model/coupled_pendulum/controlboard_plugin_device";
     yarp::dev::PolyDriver* driver;
     yarp::dev::IControlLimits* iControlLimits = nullptr;
     IControlBoardData* iControlBoardData = nullptr;
 
     gz::common::Console::SetVerbosity(4);
-    gz::sim::TestFixture testFixture{sdfPath};
 
     testFixture.OnConfigure([&](const gz::sim::Entity& _worldEntity,
                                 const std::shared_ptr<const sdf::Element>& /*_sdf*/,

--- a/tests/controlboard/ControlBoardOnMultipleGazeboInstancesTest.cc
+++ b/tests/controlboard/ControlBoardOnMultipleGazeboInstancesTest.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <iomanip>
 #include <ios>
@@ -59,10 +60,12 @@ TEST(ControlBoardOnMultipleGazeboInstances, StartConcurrentGazeboInstances)
     unsigned int iterationsToCompleteMotion1 = 0;
     unsigned int iterationsToCompleteMotion2 = 0;
 
-    gz::sim::TestFixture fixture1("../../../tests/controlboard/"
-                                  "pendulum_multiple_gz_instances.sdf");
-    gz::sim::TestFixture fixture2("../../../tests/controlboard/"
-                                  "pendulum_multiple_gz_instances.sdf");
+    gz::sim::TestFixture fixture1(
+        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "pendulum_multiple_gz_instances.sdf")
+            .string());
+    gz::sim::TestFixture fixture2(
+        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "pendulum_multiple_gz_instances.sdf")
+            .string());
     gz::common::Console::SetVerbosity(4);
 
     fixture1

--- a/tests/controlboard/ControlBoardPositionControlTest.cc
+++ b/tests/controlboard/ControlBoardPositionControlTest.cc
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -45,7 +46,9 @@ class ControlBoardPositionFixture : public testing::Test
 protected:
     // void SetUp() override
     ControlBoardPositionFixture()
-        : testFixture{"../../../tests/controlboard/pendulum_joint_relative_to_parent_link.sdf"}
+        : testFixture{(std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR)
+                       / "pendulum_joint_relative_to_parent_link.sdf")
+                          .string()}
     {
         gz::common::Console::SetVerbosity(4);
 

--- a/tests/controlboard/ControlBoardPositionDirectControlTest.cc
+++ b/tests/controlboard/ControlBoardPositionDirectControlTest.cc
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <numeric>
@@ -48,7 +49,9 @@ class ControlBoardPositionDirectFixture : public ::testing::Test
 protected:
     // void SetUp() override
     ControlBoardPositionDirectFixture()
-        : testFixture{"../../../tests/controlboard/pendulum_joint_relative_to_parent_link.sdf"}
+        : testFixture{(std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR)
+                       / "pendulum_joint_relative_to_parent_link.sdf")
+                          .string()}
     {
         gz::common::Console::SetVerbosity(4);
 

--- a/tests/controlboard/ControlBoardTorqueControlTest.cc
+++ b/tests/controlboard/ControlBoardTorqueControlTest.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -40,12 +41,10 @@ class ControlBoardTorqueControlFixture : public testing::TestWithParam<std::stri
 protected:
     // void SetUp() override
     ControlBoardTorqueControlFixture()
-        : testFixture{"../../../tests/controlboard/" + GetParam()}
+        : testFixture{(std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / GetParam()).string()}
     {
         std::cerr << "========== Test Parameter: " << GetParam() << std::endl;
         gz::common::Console::SetVerbosity(4);
-
-        // testFixture = gz::sim::TestFixture{"../../../tests/controlboard/" + GetParam()};
 
         testFixture.
             // Use configure callback to get values at startup

--- a/tests/forcetorque/CMakeLists.txt
+++ b/tests/forcetorque/CMakeLists.txt
@@ -13,3 +13,5 @@ list(APPEND _env_vars "GZ_SIM_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:gz-sim-yarp-f
 
 set_tests_properties(ForceTorqueTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
+target_compile_definitions(ForceTorqueTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/forcetorque/ForceTorqueTest.cc
+++ b/tests/forcetorque/ForceTorqueTest.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstddef>
+#include <filesystem>
 #include <string>
 #include <thread>
 
@@ -22,7 +23,8 @@ TEST(ForceTorqueTest, PluginTest)
     gz::common::Console::SetVerbosity(4);
 
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/forcetorque/model.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
 
     int iterations = 1000;
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);

--- a/tests/imu/CMakeLists.txt
+++ b/tests/imu/CMakeLists.txt
@@ -19,3 +19,5 @@ list(APPEND _env_vars "GZ_SIM_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:gz-sim-yarp-i
 
 set_tests_properties(ImuTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
+target_compile_definitions(ImuTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/imu/ImuTest.cc
+++ b/tests/imu/ImuTest.cc
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <thread>
@@ -26,7 +27,7 @@ class ImuFixture : public testing::Test
 {
 protected:
     ImuFixture()
-        : testFixture{"../../../tests/imu/model.sdf"}
+        : testFixture{(std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model.sdf").string()}
     {
         gz::common::Console::SetVerbosity(4);
 

--- a/tests/laser/CMakeLists.txt
+++ b/tests/laser/CMakeLists.txt
@@ -14,3 +14,5 @@ list(APPEND _env_vars "LIBGL_ALWAYS_SOFTWARE=1")
 
 set_tests_properties(LaserTest PROPERTIES
   ENVIRONMENT "${_env_vars}")
+
+target_compile_definitions(LaserTest PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/laser/LaserTest.cc
+++ b/tests/laser/LaserTest.cc
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <filesystem>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -22,7 +23,8 @@ TEST(LaserTest, PluginTest)
     gz::common::Console::SetVerbosity(4);
 
     // Instantiate test fixture
-    gz::sim::TestFixture fixture("../../../tests/laser/model.sdf");
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "model.sdf";
+    gz::sim::TestFixture fixture(modelPath.string());
 
     int iterations = 1000;
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);


### PR DESCRIPTION
Fixes #164 