### PR TITLE
Fix links to section in Table of Contents of how-to-migrate-from-gazebo.md

### DIFF
--- a/docs/how-to-migrate-from-gazebo-classic.md
+++ b/docs/how-to-migrate-from-gazebo-classic.md
@@ -3,11 +3,11 @@
 ## Table of Contents
 
 - [Introduction](#introduction)
-- [Update of the robot model](update-of-the-robot-model)
-- [Update of plugins configurations](update-of-plugins-configuration)
-- [World set up](world-set-up)
-- [Environment variables](environment-variables)
-- [Examples of projects with Modern Gazebo support](examples-of-projects-with-modern-gazebo-support)
+- [Update of the robot model](#update-of-the-robot-model)
+- [Update of plugins configurations](#update-of-plugins-configuration)
+- [World set up](#world-set-up)
+- [Environment variables](#environment-variables)
+- [Examples of projects with Modern Gazebo support](#examples-of-projects-with-modern-gazebo-support)
 
 ## Introduction
 

--- a/docs/how-to-migrate-from-gazebo-classic.md
+++ b/docs/how-to-migrate-from-gazebo-classic.md
@@ -4,7 +4,7 @@
 
 - [Introduction](#introduction)
 - [Update of the robot model](#update-of-the-robot-model)
-- [Update of plugins configurations](#update-of-plugins-configuration)
+- [Update of plugins configurations](#update-of-plugins-configurations)
 - [World set up](#world-set-up)
 - [Environment variables](#environment-variables)
 - [Examples of projects with Modern Gazebo support](#examples-of-projects-with-modern-gazebo-support)


### PR DESCRIPTION
The links reported in the Table of Contents which seems to be broken. Trying to fix them by adding `#` character where missing.