### PR TITLE
hijack VOCAB_CM_FORCE_IDLE to VOCAB_CM_IDLE

### DIFF
--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -252,7 +252,8 @@ bool ControlBoardDriver::setControlMode(const int j, const int mode)
         return false;
     }
 
-    m_controlBoardData->joints.at(j).controlMode = mode;
+    m_controlBoardData->joints.at(j).controlMode = (mode == VOCAB_CM_FORCE_IDLE) ? VOCAB_CM_IDLE
+                                                                                 : mode;
 
     return true;
 }

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -233,6 +233,8 @@ bool ControlBoardDriver::setControlMode(const int j, const int mode)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
+    int desired_mode = mode;
+
     if (j < 0 || j >= m_controlBoardData->joints.size())
     {
         yError() << "Error while setting control mode: joint index out of range";
@@ -252,19 +254,20 @@ bool ControlBoardDriver::setControlMode(const int j, const int mode)
         return false;
     }
 
-       // If joint is in hw fault, only a force idle command can recover it
-    if (m_controlBoardData->joints.at(j).controlMode == VOCAB_CM_HW_FAULT && mode != VOCAB_CM_FORCE_IDLE){
+    // If joint is in hw fault, only a force idle command can recover it
+    if (m_controlBoardData->joints.at(j).controlMode == VOCAB_CM_HW_FAULT
+        && mode != VOCAB_CM_FORCE_IDLE)
+    {
         return true;
     }
 
     if (mode == VOCAB_CM_FORCE_IDLE)
     {
         // Clean the fault status and set control mode to idle
-        mode = VOCAB_CM_IDLE;
+        desired_mode = VOCAB_CM_IDLE;
     }
 
-    m_controlBoardData->joints.at(j).controlMode = mode;
-                                                                                 : mode;
+    m_controlBoardData->joints.at(j).controlMode = desired_mode;
 
     return true;
 }

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -252,7 +252,18 @@ bool ControlBoardDriver::setControlMode(const int j, const int mode)
         return false;
     }
 
-    m_controlBoardData->joints.at(j).controlMode = (mode == VOCAB_CM_FORCE_IDLE) ? VOCAB_CM_IDLE
+       // If joint is in hw fault, only a force idle command can recover it
+    if (m_controlBoardData->joints.at(j).controlMode == VOCAB_CM_HW_FAULT && mode != VOCAB_CM_FORCE_IDLE){
+        return true;
+    }
+
+    if (mode == VOCAB_CM_FORCE_IDLE)
+    {
+        // Clean the fault status and set control mode to idle
+        mode = VOCAB_CM_IDLE;
+    }
+
+    m_controlBoardData->joints.at(j).controlMode = mode;
                                                                                  : mode;
 
     return true;


### PR DESCRIPTION
This PR addresses the issue reported in https://github.com/robotology/gz-sim-yarp-plugins/issues/171.

The control mode identified by number `control mode  1818519910` is `VOCAB_CM_FORCE_IDLE`.

This VOCAB_CM_FORCE_IDLE mode is set when clicking on the **idle** button in the **yarpmotorgui**. 
