### PR TITLE
 Remove useless checkNetwork calls in plugins that do not require the YARP network

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -97,8 +97,7 @@ jobs:
       run: |
         cd build
         # ImuTest, ForceTorqueTest are skipped due to https://github.com/robotology/gz-sim-yarp-plugins/issues/54
-        # ConfigurationParsingTest is skipped due to https://github.com/robotology/gz-sim-yarp-plugins/issues/90
-        ctest -E "^LaserTest|^CameraTest|^ImuTest|^ForceTorqueTest|^ControlBoardCommonsTest|^ConfigurationParsingTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -E "^LaserTest|^CameraTest|^ImuTest|^ForceTorqueTest|^ControlBoardCommonsTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Install
       run: |

--- a/plugins/camera/Camera.cc
+++ b/plugins/camera/Camera.cc
@@ -76,11 +76,6 @@ public:
                            EventManager& /*_eventMgr*/) override
     {
         yarp::os::Network::init();
-        if (!yarp::os::Network::checkNetwork())
-        {
-            yError() << "Yarp network does not seem to be available, is the yarpserver running?";
-            return;
-        }
 
         ecm = &_ecm;
 

--- a/plugins/forcetorque/ForceTorque.cc
+++ b/plugins/forcetorque/ForceTorque.cc
@@ -67,11 +67,6 @@ public:
                            EventManager& /*_eventMgr*/) override
     {
         yarp::os::Network::init();
-        if (!yarp::os::Network::checkNetwork())
-        {
-            yError() << "Yarp network does not seem to be available, is the yarpserver running?";
-            return;
-        }
 
         ecm = &_ecm;
 

--- a/plugins/laser/Laser.cc
+++ b/plugins/laser/Laser.cc
@@ -73,11 +73,6 @@ public:
                            EventManager& /*_eventMgr*/) override
     {
         yarp::os::Network::init();
-        if (!yarp::os::Network::checkNetwork())
-        {
-            yError() << "Yarp network does not seem to be available, is the yarpserver running?";
-            return;
-        }
 
         ::yarp::dev::Drivers::factory().add(
             new ::yarp::dev::DriverCreatorOf<::yarp::dev::gzyarp::LaserDriver>("gazebo_laser",

--- a/plugins/robotinterface/RobotInterface.cc
+++ b/plugins/robotinterface/RobotInterface.cc
@@ -72,12 +72,6 @@ public:
                            EventManager& /*_eventMgr*/) override
     {
         yarp::os::Network::init();
-        if (!yarp::os::Network::checkNetwork())
-        {
-            yError() << "gz-sim-yarp-robotinterface-system : yarp network does not seem to be "
-                        "available, is the yarpserver running?";
-            return;
-        }
         auto model = Model(_entity);
 
         if (!loadYarpRobotInterfaceConfigurationFile(_sdf, _ecm, model))


### PR DESCRIPTION
`yarp::os::Network::checkNetwork()` check that the yarpserver (the name server related to YARP ports) is available. However, since in gazebo-yarp-plugins we decouple the regular plugin and the YARP network wrapper server, there is no strict requirement anymore for the yarpserver is up, a user could simply run some devices without any yarpserver.

I noticed this as in my machine the `ConfigurationParsingTest` were segfaulting, until I fixed this. Hopefully this was also the reason why the tests were failing in the macOS CI.