### PR TITLE
Remove inclusion of deprecated FrameGrabber header

### DIFF
--- a/plugins/camera/CameraDriver.cpp
+++ b/plugins/camera/CameraDriver.cpp
@@ -8,7 +8,6 @@
 
 #include <string>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>

--- a/tests/camera/CameraTest.cc
+++ b/tests/camera/CameraTest.cc
@@ -8,7 +8,6 @@
 #include <gz/common/Console.hh>
 #include <gz/sim/TestFixture.hh>
 
-#include <yarp/dev/FrameGrabberInterfaces.h>
 #include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Network.h>


### PR DESCRIPTION
Fix warning:

~~~
 [4/53] Building CXX object plugins\camera\CMakeFiles\gz-sim-yarp-camera-system.dir\CameraDriver.cpp.obj
C:\Users\runneradmin\micromamba\envs\gzyarppluginsdev\Library\include\yarp/dev/FrameGrabberInterfaces.h(11) : warning:"<yarp/dev/FrameGrabberInterfaces.h> file is deprecated"
[5/53] Building CXX object libraries\device-registry\CMakeFiles\gz-sim-yarp-device-registry.dir\DeviceRegistry.cc.obj
~~~

not sure why, but somehow the warning was printed just on Windows.