### PR TITLE
Fix robotinterface plugin crashes by closing it as soon as one of its devices is destroyed

### DIFF
--- a/libraries/device-registry/DeviceRegistry.cc
+++ b/libraries/device-registry/DeviceRegistry.cc
@@ -1,9 +1,10 @@
 #include <DeviceRegistry.hh>
 
-#include <cstddef>
 #include <gz/sim/Entity.hh>
 #include <gz/sim/EntityComponentManager.hh>
 #include <gz/sim/Util.hh>
+
+#include <cstddef>
 #include <iostream>
 #include <mutex>
 #include <ostream>

--- a/libraries/device-registry/DeviceRegistry.cc
+++ b/libraries/device-registry/DeviceRegistry.cc
@@ -242,6 +242,7 @@ bool DeviceRegistry::removeDevice(const gz::sim::EntityComponentManager& ecm,
                 return false;
             }
 
+            m_deviceRemovedEvent(deviceDatabaseKey);
             m_devicesMap.at(gzInstanceId).erase(deviceDatabaseKey);
         }
     }

--- a/libraries/device-registry/DeviceRegistry.hh
+++ b/libraries/device-registry/DeviceRegistry.hh
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <gz/common/Event.hh>
 #include <gz/sim/Entity.hh>
+
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -37,6 +39,15 @@ public:
     bool
     removeDevice(const gz::sim::EntityComponentManager& ecm, const std::string& deviceDatabaseKey);
 
+    /**
+     * Add a callback when a device is removed, i.e. removeDevice is called.
+     */
+    template<typename T>
+    gz::common::ConnectionPtr connectDeviceRemoved(T _subscriber)
+    {
+        return m_deviceRemovedEvent.Connect(_subscriber);
+    }
+
     std::vector<std::string> getDevicesKeys(const gz::sim::EntityComponentManager& ecm) const;
 
 private:
@@ -54,7 +65,12 @@ private:
     static DeviceRegistry* s_handle;
     static std::mutex& mutex();
     std::unordered_map<std::string, std::unordered_map<std::string, yarp::dev::PolyDriver*>>
-        m_devicesMap; // map of known yarp devices
+        m_devicesMap; // map of known yarp devices Updated upstream
+
+    // Number of gz-sim-yarp-plugins YARP devices not loaded correctly for a given ecm
+    std::unordered_map<std::string, std::size_t> m_nrOfGzSimYARPPluginsNotSuccessfullyLoaded;
+    // Event for when a device is removed
+    gz::common::EventT<void (std::string)> m_deviceRemovedEvent;
 };
 
 } // namespace gzyarp

--- a/libraries/device-registry/DeviceRegistry.hh
+++ b/libraries/device-registry/DeviceRegistry.hh
@@ -66,9 +66,6 @@ private:
     static std::mutex& mutex();
     std::unordered_map<std::string, std::unordered_map<std::string, yarp::dev::PolyDriver*>>
         m_devicesMap; // map of known yarp devices Updated upstream
-
-    // Number of gz-sim-yarp-plugins YARP devices not loaded correctly for a given ecm
-    std::unordered_map<std::string, std::size_t> m_nrOfGzSimYARPPluginsNotSuccessfullyLoaded;
     // Event for when a device is removed
     gz::common::EventT<void (std::string)> m_deviceRemovedEvent;
 };

--- a/libraries/device-registry/DeviceRegistry.hh
+++ b/libraries/device-registry/DeviceRegistry.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gz/common/Event.hh>
+#include <gz/common/events/Types.hh>
 #include <gz/sim/Entity.hh>
 
 #include <mutex>

--- a/plugins/robotinterface/RobotInterface.cc
+++ b/plugins/robotinterface/RobotInterface.cc
@@ -1,12 +1,14 @@
 #include <ConfigurationHelpers.hh>
 #include <DeviceRegistry.hh>
 
+#include <functional>
 #include <memory>
 #include <sdf/Element.hh>
 #include <string>
 #include <vector>
 
 #include <gz/common/Event.hh>
+#include <gz/common/events/Types.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/sim/Entity.hh>
 #include <gz/sim/EntityComponentManager.hh>

--- a/plugins/robotinterface/RobotInterface.cc
+++ b/plugins/robotinterface/RobotInterface.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include <gz/common/Event.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/sim/Entity.hh>
 #include <gz/sim/EntityComponentManager.hh>
@@ -62,8 +63,21 @@ public:
                 yError() << "gz-sim-yarp-robotinterface-system: impossible  to run phase "
                             "ActionPhaseShutdown in robotinterface";
             }
+            m_connection.reset();
             m_robotInterfaceCorrectlyStarted = false;
         }
+    }
+
+    void OnDeviceRemoved(std::string removeDeviceRegistryDatabaseKey)
+    {
+        // Check if deviceRegistryDatabaseKey is among the one passed to this instance of gz_yarp_robotinterface
+        // If yes, close the robotinterface to avoid crashes due to access to a device that is being deleted
+        for (auto&& usedDeviceScopedName: m_deviceScopedNames) {
+            if (removeDeviceRegistryDatabaseKey == usedDeviceScopedName) {
+                CloseRobotInterface();
+            }
+        }
+        return;
     }
 
     virtual void Configure(const Entity& _entity,
@@ -105,11 +119,17 @@ public:
             return;
         }
         m_robotInterfaceCorrectlyStarted = true;
+        // If the robotinterface started correctly, add a callback to ensure that it is closed as
+        // soon that an external device passed to it is deleted
+        m_connection =
+            DeviceRegistry::getHandler()->connectDeviceRemoved(
+                std::bind(&RobotInterface::OnDeviceRemoved, this, std::placeholders::_1));
     }
 
 private:
     yarp::robotinterface::XMLReaderResult m_xmlRobotInterfaceResult;
     std::vector<std::string> m_deviceScopedNames;
+    gz::common::ConnectionPtr m_connection;
     bool m_robotInterfaceCorrectlyStarted;
 
     bool loadYarpRobotInterfaceConfigurationFile(const std::shared_ptr<const sdf::Element>& _sdf,


### PR DESCRIPTION
Fix https://github.com/robotology/gz-sim-yarp-plugins/issues/185 .

As the destroying order of the Gazedo entities is not reversed, it occurred that the robotinterface plugin crashed as it was still calling devices that were already destroyed. This PR fixes this problem by closing the robotinterface plugin as soon as one of the devices to which it is attached is destroyed. Basically this is a port of https://github.com/robotology/gazebo-yarp-plugins/pull/619 to gz-sim-yarp-plugins.