### PR TITLE
camera: Cleanup memory handling of CameraData

### DIFF
--- a/plugins/camera/Camera.cc
+++ b/plugins/camera/Camera.cc
@@ -123,12 +123,7 @@ public:
         auto sdfSensor = _ecm.ComponentData<components::Camera>(sensor).value().Element();
         auto sdfImage = sdfSensor.get()->GetElement("camera").get()->GetElement("image").get();
 
-        cameraData.m_height = sdfImage->Get<int>("height");
-        cameraData.m_width = sdfImage->Get<int>("width");
-        cameraData.m_bufferSize = 3 * cameraData.m_width * cameraData.m_height;
-
-        sensorScopedName = scopedName(this->sensor, _ecm);
-        this->cameraData.sensorScopedName = sensorScopedName;
+        cameraData.init(sdfImage->Get<int>("width"), sdfImage->Get<int>("height"), sensorScopedName);
 
         driver_properties.put(YarpCameraScopedName.c_str(), sensorScopedName.c_str());
 

--- a/plugins/camera/CameraDriver.cpp
+++ b/plugins/camera/CameraDriver.cpp
@@ -76,8 +76,6 @@ public:
 
     bool close() override
     {
-        delete[] m_sensorData->m_imageBuffer;
-        m_sensorData->m_imageBuffer = 0;
         return true;
     }
 
@@ -269,18 +267,6 @@ public:
     void setCameraData(::gzyarp::CameraData* dataPtr) override
     {
         m_sensorData = dataPtr;
-
-        // Now that we have a pointer to CameraData we can initialize the camera buffers
-        initializeCamera();
-    }
-
-    void initializeCamera()
-    {
-        {
-            std::lock_guard<std::mutex> lock(m_sensorData->m_mutex);
-            m_sensorData->m_imageBuffer = new unsigned char[getRawBufferSize()];
-            memset(m_sensorData->m_imageBuffer, 0x00, getRawBufferSize());
-        }
     }
 
 private:

--- a/plugins/camera/CameraShared.hh
+++ b/plugins/camera/CameraShared.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdlib>
 #include <mutex>
 #include <string>
 
@@ -9,12 +10,31 @@ namespace gzyarp
 struct CameraData
 {
     std::mutex m_mutex;
-    int m_width;
-    int m_height;
-    int m_bufferSize;
-    unsigned char* m_imageBuffer;
-    std::string sensorScopedName;
-    double simTime;
+    int m_width=0;
+    int m_height=0;
+    int m_bufferSize=0;
+    unsigned char* m_imageBuffer=nullptr;
+    std::string sensorScopedName="";
+    double simTime=0.0;
+
+    void init(const int width, const int height, const std::string& _sensorScopedName)
+    {
+        this->m_height = height;
+        this->m_width = width;
+        this->m_bufferSize = 3 * this->m_width * this->m_height;
+        this->m_imageBuffer = static_cast<unsigned char*>(std::calloc(this->m_bufferSize, sizeof(unsigned char)));
+        this->sensorScopedName = _sensorScopedName;
+        return;
+    }
+
+    ~CameraData()
+    {
+        if (m_imageBuffer)
+        {
+            free(m_imageBuffer);
+            m_imageBuffer = nullptr;
+        }
+    }
 };
 
 class ICameraData


### PR DESCRIPTION
I was starting to look into the Camera plugin to understand a bit of segfaults, and I noticed that the handling of data in `CameraData` was a bit complex. In particular, the only used `CameraData` instance was a local variable of the `gzyarp::Camera` gz-sim plugin, that then is passed via the `setCameraData` function to `gzyarp::CameraDriver` YARP device, where the `m_imageBuffer`  buffer was allocated. To simplify everything, I just moved all the initialization to a `init` method of `CameraData`, and I called `init` in the method of  `gzyarp::Camera` gz-sim plugin.