### PR TITLE
Fix ClockTest on Windows

### DIFF
--- a/tests/clock/ClockTest.cc
+++ b/tests/clock/ClockTest.cc
@@ -22,14 +22,14 @@ TEST(ClockTest, GetSimulationTimeFromClockPort)
     gz::sim::TestFixture fixture(modelPath.string());
     fixture.Finalize();
 
-    const int iterations = 1000;
+    const int iterations = 10;
     const int deltaTns = 1e6; // 1ms
     const int tolerance = 1e6; // 1ms
     yarp::os::BufferedPort<yarp::os::Bottle> p; // Create a port.
     p.open("/tmp_in"); // Give it a name on the network.
     yarp::os::Network::connect("/clock", "/tmp_in"); // connect two ports.
-    int expectedSimTimeSeconds = (iterations - 1) / 1e3;
-    int expectedSimTimeNanoseconds = 0;
+    int expectedSimTimeSeconds = iterations / 1e3;
+    int expectedSimTimeNanoseconds = static_cast<int>(iterations * deltaTns) % 1'000'000'000;
 
     // ACT
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);
@@ -40,6 +40,6 @@ TEST(ClockTest, GetSimulationTimeFromClockPort)
     auto simTimeSeconds = b->get(0).asInt32();
     auto simTimeNanoseconds = b->get(1).asInt32();
 
-    ASSERT_NEAR(simTimeSeconds, expectedSimTimeSeconds, tolerance);
+    ASSERT_EQ(simTimeSeconds, expectedSimTimeSeconds);
     ASSERT_NEAR(simTimeNanoseconds, expectedSimTimeNanoseconds, tolerance);
 }


### PR DESCRIPTION
Without these changes, the ClockTest is not passing on Windows, the changes are:
* Go back to run the simulation just for ~10 iterations (i.e. 10 ms), and compute correctly the expected nanoseconds published on the clock (without doing `iterations-1` that was what was causing the test to fail on Windows). Furthermore, do not use 1e6 seconds as tolerance for seconds, but just expect them to be equal.
* Add `Finalize()` call to the fixture, otherwise there was a "[Wrn] [D:\bld\gz-sim8_1713968558858\work\src\TestFixture.cc:208] Fixture has not been finalized, any functions you attemptedto hook into will not be run. It is recommended to call Finalize()before accessing the server." warning
