### PR TITLE
Fix non-determistic reading of constant zero values for imu and laser plugin

### DIFF
--- a/plugins/imu/Imu.cc
+++ b/plugins/imu/Imu.cc
@@ -202,7 +202,7 @@ private:
     std::string sensorScopedName;
     bool m_deviceRegistered;
     ::gzyarp::ImuData imuData;
-    bool imuInitialized;
+    bool imuInitialized{false};
     gz::transport::Node node;
     gz::msgs::IMU imuMsg;
     std::mutex imuMsgMutex;

--- a/plugins/laser/Laser.cc
+++ b/plugins/laser/Laser.cc
@@ -197,7 +197,7 @@ private:
     std::string sensorScopedName;
     bool m_deviceRegistered;
     LaserData laserData;
-    bool laserInitialized;
+    bool laserInitialized{false};
     gz::transport::Node node;
     gz::msgs::LaserScan laserMsg;
     std::mutex laserMsgMutex;


### PR DESCRIPTION
Fix problem similar to https://github.com/robotology/gz-sim-yarp-plugins/pull/193 for `imu` and `laser` plugins.