### PR TITLE
Reduce test skip and options to tolerate non-deterministic failure

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -100,15 +100,13 @@ jobs:
       if: contains(matrix.build_type, 'Release')
       run: |
         cd build
-        # So high until-pass as a mitigation for https://github.com/robotology/gz-sim-yarp-plugins/issues/75
-        ctest -E "^ImuTest" --repeat until-pass:20 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test (Debug)
       if: contains(matrix.build_type, 'Debug')
       run: |
         cd build
-        # So high until-pass as a mitigation for https://github.com/robotology/gz-sim-yarp-plugins/issues/75
-        ctest -T Test -T Coverage --repeat until-pass:20 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -T Test -T Coverage --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Install
       run: |

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -100,13 +100,20 @@ jobs:
       if: contains(matrix.build_type, 'Release')
       run: |
         cd build
-        ctest --output-on-failure -C ${{ matrix.build_type }} .
+        # Deterministic tests
+        ctest -E "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
+        # Non-deterministic tests
+        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --repeat until-pass:5  --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test (Debug)
       if: contains(matrix.build_type, 'Debug')
       run: |
         cd build
-        ctest -T Test -T Coverage --output-on-failure -C ${{ matrix.build_type }} .
+        # Deterministic tests
+        ctest -E "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest"  -T Test -T Coverage --output-on-failure -C ${{ matrix.build_type }} .
+        # Non-deterministic tests
+        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" -T Test -T Coverage --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+
 
     - name: Install
       run: |

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -112,7 +112,7 @@ jobs:
         # Deterministic tests
         ctest -E "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest"  -T Test -T Coverage --output-on-failure -C ${{ matrix.build_type }} .
         # Non-deterministic tests
-        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" -T Test -T Coverage --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" -T Test -T Coverage --repeat until-pass:10 --output-on-failure -C ${{ matrix.build_type }} .
 
 
     - name: Install

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -103,7 +103,7 @@ jobs:
         # Deterministic tests
         ctest -E "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
         # Non-deterministic tests
-        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --repeat until-pass:5  --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --repeat until-pass:10  --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test (Debug)
       if: contains(matrix.build_type, 'Debug')

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -89,11 +89,8 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        # Deterministic tests
+        # LaserTest and CameraTest are failing on conda-forge on Ubuntu: https://github.com/robotology/gz-sim-yarp-plugins/issues/196
         ctest -E "^LaserTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
-        # Non-deterministic tests
-        ctest -R "^LaserTest|^CameraTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
-
 
     - name: Test_macos
       if: contains(matrix.os, 'macos')

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -89,15 +89,14 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        ctest -E "^LaserTest|^CameraTest|^ImuTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test_macos
       if: contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
         cd build
-        # ImuTest, ForceTorqueTest are skipped due to https://github.com/robotology/gz-sim-yarp-plugins/issues/54
-        ctest -E "^LaserTest|^CameraTest|^ImuTest|^ForceTorqueTest|^ControlBoardCommonsTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Install
       run: |

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -89,7 +89,11 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        ctest --output-on-failure -C ${{ matrix.build_type }} .
+        # Deterministic tests
+        ctest -E "^LaserTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
+        # Non-deterministic tests
+        ctest -R "^LaserTest|^CameraTest" --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+
 
     - name: Test_macos
       if: contains(matrix.os, 'macos')


### PR DESCRIPTION
We recently have a few PRs that solved non-deterministic failures:
* https://github.com/robotology/gz-sim-yarp-plugins/pull/193
* https://github.com/robotology/gz-sim-yarp-plugins/pull/194
* https://github.com/robotology/gz-sim-yarp-plugins/pull/186

Thanks to these fixes, we can reduce the number of workarounds, and only run multiple times tests that are known to be flaky.