### PR TITLE
Set LIBGL_ALWAYS_SOFTWARE=true in test to avoid LaserTest and CameraTest segmentation fault on test exit

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -90,7 +90,8 @@ jobs:
       run: |
         cd build
         # LaserTest and CameraTest are failing on conda-forge on Ubuntu: https://github.com/robotology/gz-sim-yarp-plugins/issues/196
-        ctest -E "^LaserTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
+        export LIBGL_ALWAYS_SOFTWARE=true
+        ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test_macos
       if: contains(matrix.os, 'macos')

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -91,6 +91,7 @@ jobs:
         cd build
         # LaserTest and CameraTest are failing on conda-forge on Ubuntu: https://github.com/robotology/gz-sim-yarp-plugins/issues/196
         sudo apt install libegl-dev libegl-mesa0 libegl1
+        ldd $CONDA_PREFIX/lib/OGRE-Next/RenderSystem_GL3Plus.so
         ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test_macos

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -90,7 +90,7 @@ jobs:
       run: |
         cd build
         # LaserTest and CameraTest are failing on conda-forge on Ubuntu: https://github.com/robotology/gz-sim-yarp-plugins/issues/196
-        export LIBGL_ALWAYS_SOFTWARE=true
+        sudo apt install libegl-dev libegl-mesa0 libegl1
         ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test_macos

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -91,6 +91,7 @@ jobs:
         cd build
         # LaserTest and CameraTest are failing on conda-forge on Ubuntu: https://github.com/robotology/gz-sim-yarp-plugins/issues/196
         sudo apt install libegl-dev libegl-mesa0 libegl1
+        export GZ_ENGINE_HEADLESS=1
         ldd $CONDA_PREFIX/lib/OGRE-Next/RenderSystem_GL3Plus.so
         ctest --output-on-failure -C ${{ matrix.build_type }} .
 


### PR DESCRIPTION
Test related to https://github.com/robotology/gz-sim-yarp-plugins/issues/196 .