### PR TITLE
Add workaround for "ODE INTERNAL ERROR 1: assertion "!colliders_initialized" failed in dInitColliders() [collision_kernel.cpp:168]" crash

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -101,18 +101,18 @@ jobs:
       run: |
         cd build
         # Deterministic tests
-        ctest -E "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -E "^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
         # Non-deterministic tests
-        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" --repeat until-pass:10  --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -R "^CameraTest" --repeat until-pass:10  --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Test (Debug)
       if: contains(matrix.build_type, 'Debug')
       run: |
         cd build
         # Deterministic tests
-        ctest -E "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest"  -T Test -T Coverage --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -E "^CameraTest"  -T Test -T Coverage --output-on-failure -C ${{ matrix.build_type }} .
         # Non-deterministic tests
-        ctest -R "^ConcurrentInstancesTest|^ControlBoardOnMultipleGazeboInstancesTest|^CameraTest" -T Test -T Coverage --repeat until-pass:10 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest -R "^CameraTest" -T Test -T Coverage --repeat until-pass:10 --output-on-failure -C ${{ matrix.build_type }} .
 
 
     - name: Install

--- a/tests/commons/ConcurrentInstancesTest.cc
+++ b/tests/commons/ConcurrentInstancesTest.cc
@@ -13,22 +13,30 @@ TEST(ConcurrentInstancesTest, StartConcurrentGazeboInstancesOfDifferentModels)
 {
     auto plannedIterations = 1'000;
 
-    gz::sim::TestFixture fixture1(
-        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "dummy_sphere.sdf").string());
-    gz::sim::TestFixture fixture2(
-        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "dummy_box.sdf").string());
     gz::common::Console::SetVerbosity(4);
 
+
+    gz::sim::TestFixture fixture1(
+        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "dummy_sphere.sdf").string());
     fixture1.Finalize();
+
+    // Workaround for https://github.com/robotology/gz-sim-yarp-plugins/issues/201
+
+    gz::sim::TestFixture fixture2(
+        (std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "dummy_box.sdf").string());
     fixture2.Finalize();
 
-    ASSERT_TRUE(fixture1.Server()->Run(false, plannedIterations, false));
-    ASSERT_TRUE(fixture2.Server()->Run(false, plannedIterations, false));
+    // First do a step blocked to workaround https://github.com/robotology/gz-sim-yarp-plugins/issues/20
+    // Remove if and once https://github.com/gazebosim/gz-physics/pull/675 is merged
+    ASSERT_TRUE(fixture1.Server()->Run(/*blocking=*/true, 1, /*paused=*/false));
+    ASSERT_TRUE(fixture2.Server()->Run(/*blocking=*/true, 1, /*paused=*/false));
+
+    ASSERT_TRUE(fixture1.Server()->Run(/*paused=*/false, plannedIterations-1, /*paused=*/false));
+    ASSERT_TRUE(fixture2.Server()->Run(/*paused=*/false, plannedIterations-1, /*paused=*/false));
 
     while (fixture1.Server()->Running() || fixture2.Server()->Running())
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        std::cerr << "Waiting for Gazebo simulation to finish..." << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     ASSERT_EQ(fixture1.Server()->IterationCount(), plannedIterations);


### PR DESCRIPTION
This PR adds a simple workaround for the non-deterministic crashes with messages:

> ODE INTERNAL ERROR 1: assertion "!colliders_initialized" failed in dInitColliders() [collision_kernel.cpp:168]

described in https://github.com/robotology/gz-sim-yarp-plugins/issues/201 . The upstream solution is https://github.com/gazebosim/gz-physics/pull/675, but while we wait for upstream feedback, this simple solution of running the first step as blocking so the two first step happen in two different times for sure should work fine. 

Fix https://github.com/robotology/gz-sim-yarp-plugins/issues/201 .