### PR TITLE
Add github workflow to automatically update pixi lockfile

### DIFF
--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -1,0 +1,42 @@
+name: Update lockfiles
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 5 1 * *
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          run-install: false
+
+      - name: Install pixi-diff-to-markdown
+        run: pixi global install pixi-diff-to-markdown
+
+      - name: Update lockfiles
+        run: |
+          set -o pipefail
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update pixi lockfile
+          title: Update pixi lockfile
+          body-path: diff.md
+          branch: update-pixi
+          base: main
+          labels: pixi
+          delete-branch: true
+          add-paths: pixi.lock


### PR DESCRIPTION
In this way, we do not risk forgetting to maintain the Pixi lock files.

The action comes from the official documentation: https://pixi.sh/dev/advanced/updates_github_actions/#how-to-use with some customizations done by @flferretti in https://github.com/ami-iit/jaxsim/pull/221

Remark: as specified in the documentation, the permission of the repo should be set as follows:
![image](https://github.com/user-attachments/assets/c9fd57e2-8b42-4f51-a846-e19dad02f637)
