### PR TITLE
Add support for both Gazebo Harmonic (gz-sim8) and Gazebo Ionic (gz-sim9)

### DIFF
--- a/.github/workflows/test-pixi.yml
+++ b/.github/workflows/test-pixi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pixi-test:
-    name: '[pixi:${{ matrix.os }}]'
+    name: '[pixi:${{ matrix.os }}:env:${{ matrix.pixi_env }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -16,6 +16,10 @@ jobs:
           macos-latest,
           # Disabled until https://github.com/robotology/gz-sim-yarp-plugins/issues/205 is fixed
           # windows-2019
+        ]
+        pixi_env: [
+          default,
+          ionic
         ]
 
     steps:
@@ -39,4 +43,4 @@ jobs:
       run: pixi info
 
     - name: Run tests
-      run: pixi run test
+      run: pixi run -e ${{ matrix.pixi_env }} test

--- a/.github/workflows/test-pixi.yml
+++ b/.github/workflows/test-pixi.yml
@@ -47,5 +47,5 @@ jobs:
     # Windows disabled due to https://github.com/robotology/gz-sim-yarp-plugins/issues/205
     # macOS on Ionic disabled due to https://github.com/robotology/gz-sim-yarp-plugins/issues/215
     - name: Run tests
-      if: !contains(matrix.os, 'windows') && !(contains(matrix.os, 'macos') && matrix.pixi_env == 'ionic')
+      if: "!contains(matrix.os, 'windows') && !(contains(matrix.os, 'macos') && matrix.pixi_env == 'ionic')"
       run: pixi run -e ${{ matrix.pixi_env }} test

--- a/.github/workflows/test-pixi.yml
+++ b/.github/workflows/test-pixi.yml
@@ -14,8 +14,7 @@ jobs:
         os: [
           ubuntu-22.04,
           macos-latest,
-          # Disabled until https://github.com/robotology/gz-sim-yarp-plugins/issues/205 is fixed
-          # windows-2019
+          windows-2019
         ]
         pixi_env: [
           default,
@@ -42,5 +41,11 @@ jobs:
     - name: Print pixi info
       run: pixi info
 
+    - name: Build the project
+      run: pixi run -e ${{ matrix.pixi_env }} build
+
+    # Windows disabled due to https://github.com/robotology/gz-sim-yarp-plugins/issues/205
+    # macOS on Ionic disabled due to https://github.com/robotology/gz-sim-yarp-plugins/issues/215
     - name: Run tests
+      if: !contains(matrix.os, 'windows') && !(contains(matrix.os, 'macos') && matrix.pixi_env == 'ionic')
       run: pixi run -e ${{ matrix.pixi_env }} test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,37 @@ project(gz-sim-yarp-plugins
         LANGUAGES CXX C
         VERSION 0.3.0)
 
-find_package(gz-cmake3 REQUIRED)
 find_package(YARP REQUIRED COMPONENTS robotinterface os)
 find_package(YCM REQUIRED)
 
-gz_find_package(gz-plugin2 REQUIRED COMPONENTS register)
-set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
+# Initial value of GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION is empty, and then is set to 8 or 9 depending if gz-sim8 or gz-sim9 are available
+set(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION_DOCS "Version of gz-sim used to compile gz-sim-yarp-plugins (either 8 or 9)")
+set(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION "" CACHE STRING ${GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION_DOCS})
 
-gz_find_package(gz-sim8 REQUIRED)
-set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
+# If GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION is not set, try to guess a suitable value
+# based on the gz-sim version that can be found in the system
+if(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION STREQUAL "")
+    find_package(gz-sim8 QUIET)
+    if(gz-sim8_FOUND)
+        set(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION "8" CACHE STRING ${GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION_DOCS} FORCE)
+    else()
+        find_package(gz-sim9 REQUIRED)
+        set(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION "9" CACHE STRING ${GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION_DOCS} FORCE)
+    endif()
+endif()
+
+if(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION STREQUAL "8")
+    set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
+    find_package(gz-plugin2 REQUIRED COMPONENTS register)
+    set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
+elseif(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION STREQUAL "9")
+    find_package(gz-sim9 REQUIRED)
+    set(GZ_SIM_VER ${gz-sim9_VERSION_MAJOR})
+    find_package(gz-plugin3 REQUIRED COMPONENTS register)
+    set(GZ_PLUGIN_VER ${gz-plugin3_VERSION_MAJOR})
+else()
+    message(FATAL_ERROR "Unsupported GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION value ${GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION}, only 8 or 9 are supported.")
+endif()
 
 option(GZ_SIM_YARP_PLUGINS_BUILD_TOOLS "If enabled, build command line helper tools" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION STREQUAL "")
 endif()
 
 if(GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION STREQUAL "8")
+    find_package(gz-sim8 REQUIRED)
     set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
     find_package(gz-plugin2 REQUIRED COMPONENTS register)
     set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -58,6 +58,12 @@ pixi shell
 
 and then run your commands as in a normal shell.
 
+The `default` environment of pixi uses Gazebo Harmonic (`gz-sim8`), if you want to use Gazebo Ionic (`gz-sim9`) just add `-e ionic` after `pixi run`, for example to run the tests under Ionic:
+
+~~~
+pixi run -e ionic test
+~~~
+
 ## Compile from source with conda on Linux, macOS or Windows
 
 If you are using conda, the dependencies of `gz-sim-yarp-plugins` can be installed with:
@@ -66,7 +72,7 @@ If you are using conda, the dependencies of `gz-sim-yarp-plugins` can be install
 conda install -c conda-forge libgz-sim8 yarp ycm-cmake-modules cmake ninja pkg-config cmake compilers gtest cli11
 ```
 
-This command should be executed in a terminal with the environment activated.
+This command should be executed in a terminal with the environment activated. If you want to use Gazebo Ionic (`gz-sim9`) in place of Gazebo Harmonic (`gz-sim8`), just change `libgz-sim8` to `libgz-sim9`.
 
 ### Build
 
@@ -101,7 +107,7 @@ sudo apt-get update
 sudo apt-get install lsb-release wget gnupg cmake pkg-config ninja-build build-essential libcli11-dev libgtest-dev
 ```
 
-and then install Gazebo Harmonic:
+and then install Gazebo:
 
 ```bash
 sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
@@ -109,6 +115,8 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-
 sudo apt-get update
 sudo apt-get install gz-harmonic
 ```
+
+If you want to use Gazebo Ionic (`gz-sim9`) in place of Gazebo Harmonic (`gz-sim8`), just change `gz-harmonic` to `gz-ionic`.
 
 Then, you need to install [`ycm-cmake-modules`](https://github.com/robotology/ycm) and [`yarp`](https://github.com/robotology/yarp), for which no apt binaries are available. You can install them easily via the `robotology-superbuild`, or otherwise with the following commands:
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -51,7 +51,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h2e2a08d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dartsim-cpp-6.14.5-h198e952_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dartsim-cpp-6.14.5-h198e952_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
@@ -191,9 +191,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-msgs10-10.3.0-h7cb8037_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-physics7-7.3.0-hb9befc3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-plugin2-2.0.3-h5888daf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-rendering8-8.2.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-rendering8-8.2.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-sensors8-8.2.0-hf54134d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-sim8-8.3.0-h81317a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-sim8-8.6.0-hb16c8d3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools2-2.0.1-h17585e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-transport13-13.4.0-h494c5e8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.0-h5888daf_0.conda
@@ -349,21 +349,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.42-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-glproto-1.4.17-hb9d3cd8_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.14-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.0-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.1.3-h4ab18f5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_1.conda
@@ -371,7 +371,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-hb9d3cd8_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_5.conda
@@ -426,7 +425,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppzmq-4.10.0-hf1bdad7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.8.0-heb6c788_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dartsim-cpp-6.14.5-hf7109e4_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dartsim-cpp-6.14.5-hf7109e4_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
@@ -563,9 +562,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-msgs10-10.3.0-hf27b65d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-physics7-7.3.0-h927b50a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-plugin2-2.0.3-h5ad3122_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-rendering8-8.2.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-rendering8-8.2.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sensors8-8.2.0-hedd66c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sim8-8.3.0-py312hd1048e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sim8-8.6.0-py312hc0bf31e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-tools2-2.0.1-h44b4b97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-transport13-13.4.0-h9c8add6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils2-2.2.0-h5ad3122_0.conda
@@ -579,7 +578,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-7_ha7e5223_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm18-18.1.8-h36f4c5c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.0-h2edbd07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.1-h2edbd07_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmicrohttpd-1.0.1-hbc975ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h9180261_114.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
@@ -713,28 +712,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xerces-c-3.2.5-h595f43b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.42-h68df207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-glproto-1.4.17-h86ecc28_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.14-hf897c2e_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h57736b2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.0-h57736b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h57736b2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.1.3-h68df207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.2-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.0-h57736b2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h86ecc28_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_5.conda
@@ -794,7 +792,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/console_bridge-1.0.2-h3e96240_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cppzmq-4.10.0-h42a7a8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-he8d86c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dartsim-cpp-6.14.5-h6521eda_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dartsim-cpp-6.14.5-h6521eda_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
@@ -905,9 +903,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-msgs10-10.3.0-h05e06dd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-physics7-7.3.0-hedffbc7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-plugin2-2.0.3-hf9b8971_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-rendering8-8.2.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-rendering8-8.2.0-hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sensors8-8.2.0-h5adfe9f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sim8-8.3.0-py312h39e8741_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sim8-8.6.0-py312he507933_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-tools2-2.0.1-hce4b3f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-transport13-13.4.0-h3cdd9d8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-utils2-2.2.0-hf9b8971_0.conda
@@ -922,7 +920,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.8-h5090b49_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.0-hbfa8675_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.1-hbfa8675_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_he469be0_114.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libode-0.16.2-py312h20a0b95_14.conda
@@ -963,7 +961,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h5e6703a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.1-hfc4440f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.0-hba312e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
@@ -1040,14 +1038,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxaw-1.0.14-h3422bc3_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxmu-1.1.3-h99b78c6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxpm-3.5.17-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxpm-3.5.17-hd74edd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxt-1.3.0-hd74edd7_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-hd74edd7_1004.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-hd74edd7_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_5.conda
@@ -1095,7 +1091,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/console_bridge-1.0.2-h5362a0b_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h42135b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.14.5-hb31bbbe_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.14.5-hb31bbbe_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dlfcn-win32-1.4.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
@@ -1188,9 +1184,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs10-10.3.0-hf246b6b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics7-7.3.0-hddb745a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin2-2.0.3-he0c23c2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering8-8.2.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering8-8.2.0-he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors8-8.2.0-h1f0e801_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.3.0-hea5eaeb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.6.0-hf2d66a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-tools2-2.0.1-h9fbcf1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport13-13.4.0-ha6d6571_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils2-2.2.0-he0c23c2_0.conda
@@ -1226,6 +1222,1317 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat14-14.5.0-hf143461_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hb151862_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.49.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-h71b8b94_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.1-h25f2845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_694.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nlopt-2.8.0-py312h1fad3b1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/octomap-1.9.8-h91493d7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-1.10.12.1-he619cb2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ogre-next-2.3.3-hb2de451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h9aba623_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openscenegraph-3.6.5-hf7c1acd_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pagmo-2.19.1-h0951c81_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre-8.45-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.08.0-h9415970_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.4-hd835ec0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.6-hce54a09_2_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h264fbc2_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.3.3-hfb80623_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.14.1-h9f2357e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.46.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.26.1-hb874448_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-4.0.1-h3a023e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-1.1.2-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py312h3ccbe7c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zziplib-0.13.69-h3ca93ac_2.conda
+  ionic:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.0-hac33072_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.31-h57bd9a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.4-hfd43aa1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.28-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-h756ea98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h29ce20c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.10-h5e77a74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h33ff4e5_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.6-h02abb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.6-h834ce55_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h756ea98_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.20-h756ea98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.3-h469002c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h9f1560d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.7.0-h10ac4d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blis-0.9.0-h4ab18f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-h25a0e75_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.33.1-heb4867d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-hf8ad068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-18-18.1.8-default_hf981a13_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-18.1.8-default_hf981a13_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cli11-2.4.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.30.4-hf9cb763_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/collada-dom-2.5.0-h6e3624d_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.8.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cppzmq-4.10.0-h2e2a08d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.8.0-h1a2810e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dartsim-cpp-6.14.5-h198e952_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.191-h924a536_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-hadc09e8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fd-find-10.2.0-h8fae777_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.0.2-gpl_h8657690_705.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h54ed35b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.8.0-h36df796_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h4bd6248_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-13.3.0-h9576a4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-13.3.0-h10434e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.3.0-hb919d3a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.1-h2ff4ddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.1-h4833e2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.7-h32866dd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.15.2-h434a139_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hdbfa832_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-h6834431_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imgui-1.91.2-h9b8e6db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsoncpp-1.9.6-h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hf8d3e68_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-24_linux64_blis.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-24_linux64_blis.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp18.1-18.1.8-default_hf981a13_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.0-default_hb5137d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.0-default_h9c6a7e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.21-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.2-ha770c72_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.2-hceee5e3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.2-h2db6552_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.2-hc3b29a1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.2-hd5ecb85_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.2-h6283f77_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.2-h1b2c38e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.2-h1df15e4_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.2-hf2d2f32_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.2-h600f43f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.2-h151b34b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.2-h151b34b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.2-h4a3bace_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.2-h03c987c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.1-h2ff4ddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.29.0-h435de7b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.29.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.3-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.0.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-common6-6.0.0-h6f2e459_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-fuel-tools10-10.0.0-h4cd16b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-gui9-9.0.0-ha98a267_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.0.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-msgs11-11.0.0-h7cb8037_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-physics8-8.0.0-hb9befc3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-plugin3-3.0.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-rendering9-9.0.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-sensors9-9.0.0-h8301ccf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-sim9-9.0.0-hb16c8d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools2-2.0.1-h17585e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-transport14-14.0.0-h5edbe1f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.0.0-h6ea83cf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.3-hcb278e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-7_ha36c22a_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-7_ha36c22a_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.8-h8b73ec9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.0-ha7bfdaf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.1-hbc5bc17_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libode-0.16.2-h30efb56_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py312h01efb12_606.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h56242b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h56242b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h358ae18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-hd5b35b9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.3-hca62329_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.0.0-hbf83bc3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h831f25b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-h84ea5a7_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.6-h2774228_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-h6565414_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.49.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-hf094a1e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.1-hf83b1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.6-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.8.0-py312h69683c5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.105-hd34e28f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.9.8-h924138e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-1.10.12.1-hfa30d70_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ogre-next-2.3.3-ha916a4f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-h04e0de5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openscenegraph-3.6.5-h6fe4003_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pagmo-2.19.1-h4fefe70_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.08.0-h47131b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.4-hb2eb5c0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.6-hc5c86c4_2_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h3155989_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.3.3-h3da8d8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.3-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.1-h9eae976_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.2.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/swig-4.2.1-hfb18ccb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.26.1-h4c922dd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024b-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-h7fd8c06_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-glproto-1.4.17-hb9d3cd8_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.14-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.1.3-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py312h9b7a4f6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-ha4adb4c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.0-hf9b3779_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.7.31-h92f6102_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.7.4-h51bfcdd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.9.28-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.2.19-h57e602e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.4.3-h7400eea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.8.10-hc7031c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.14.18-hd2a7d26_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.10.6-hd84f86a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.6.6-h2c5aa70_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.1.19-h57e602e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.1.20-h57e602e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-crt-cpp-0.28.3-h8bb245d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.407-h21cfba4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-core-cpp-1.13.0-h60f91e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-identity-cpp-1.8.0-hf0f394c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.12.0-h17ca4bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-common-cpp-12.7.0-h68dbd84_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hd2997c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-cpp-3.25-py312hc435895_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.33.1-ha64f414_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.8.0-h6561dab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cfitsio-4.4.1-h14ced4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-18-18.1.8-default_h14d1da3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-18.1.8-default_h14d1da3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cli11-2.4.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.30.4-hbb72600_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/collada-dom-2.5.0-hd760281_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compilers-1.8.0-h8af1aa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppzmq-4.10.0-hf1bdad7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.8.0-heb6c788_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dartsim-cpp-6.14.5-hf7109e4_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.191-h48015c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.3-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fcl-0.7.0-h31587c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fd-find-10.2.0-ha3529ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.2-gpl_h4bdba66_705.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-hba58ff8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-11.0.2-h70be974_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fortran-compiler-1.8.0-h25a59a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h3148b36_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h5428426_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-hcdea9b6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.13.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geotiff-1.7.3-h17a0a10_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran-13.3.0-h8a56e6e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-13.3.0-h174a3c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_linux-aarch64-13.3.0-h2809cf8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.1-hc486b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.1-h78ca943_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.7-hd1749d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.15.2-h70be974_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h1211b58_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_hd1676c9_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imgui-1.91.2-h7851d19_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jsoncpp-1.9.6-h17cf362_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kealib-1.5.3-h8fde926_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.16-h922389a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240116.2-cxx17_h0a1ffab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.7.4-h2c0effa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-7_ha7e5223_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-7_ha7e5223_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp15-15.0.7-default_hb368394_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp18.1-18.1.8-default_h14d1da3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.0-default_h4390ef5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.21-h68df207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.1.0-he277a41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-3.9.2-h8af1aa0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.9.2-h451bb2b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-fits-3.9.2-h3257f4f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.9.2-hc881715_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.9.2-h62a502c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.9.2-h1af7d16_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.9.2-h0a5b85b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-kea-3.9.2-h0f41c56_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.9.2-hf200704_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-pdf-3.9.2-h167296a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-pg-3.9.2-h546442b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-postgisraster-3.9.2-h546442b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-tiledb-3.9.2-h2bacc52_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-xls-3.9.2-hba845e4_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.1.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.1.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.1.0-h9420597_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.1-hc486b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-2.29.0-hbb89541_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-storage-2.29.0-hb9b2b65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.62.2-h98a9317_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.3-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.0.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-common6-6.0.0-hd965c31_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-fuel-tools10-10.0.0-h3aa7d20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-gui9-9.0.0-h595855f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.0.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-msgs11-11.0.0-hbbdfe00_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-physics8-8.0.0-h927b50a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-plugin3-3.0.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-rendering9-9.0.0-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sensors9-9.0.0-hcd0cff2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sim9-9.0.0-py312hc0bf31e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-tools2-2.0.1-h44b4b97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-transport14-14.0.0-h42e8520_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils2-2.2.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils3-3.0.0-h5eaaa13_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.1-default_h3030c0e_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.3-hd600fc2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h62bc5a7_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-7_ha7e5223_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-7_ha7e5223_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm18-18.1.8-h36f4c5c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.1-h2edbd07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmicrohttpd-1.0.1-hbc975ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h9180261_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libode-0.16.2-py312h2aa54b4_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312hc19e177_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-devel-1.7.0-hd24410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-hf7f153a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-hf7f153a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-hcab21d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.3-hea2c3fa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.3-hf20323b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2023.09.01-h9d008c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-hbcf326e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.0.0-h13c1794_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.20-h68df207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-h08d9e07_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-h2fd7c63_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.1-hc4a20ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.1.0-h3f4de04_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-hf1166c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.6-hd54d049_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-h431e736_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.49.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h00a45b3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h699e99e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.1-h22f5f0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h31becfc_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h2f0025b_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/minizip-4.0.7-h77a9e90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.6-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.12.1-h70be974_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlopt-2.8.0-py312h25d8ddd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.105-hbe714ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.9.8-hdd96247_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-1.10.12.1-h75c8ceb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ogre-next-2.3.3-hdfe6764_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-h78594a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openscenegraph-3.6.5-h8c5d60d_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pagmo-2.19.1-ha0f9880_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/poppler-24.08.0-h5d53d0d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/postgresql-16.4-h001cd3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.5.0-h07e4b22_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.6-h5d932e8_2_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h09b8c70_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/re2-2023.09.01-h9caee61_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.4-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.3.3-h6b37fb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.5.3-hd08dc88_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.14.1-h9d9cc24_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.46.1-h578a6b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.2.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.13.0-h17cf362_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tiledb-2.26.1-hf7e1cb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-10.0.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tzcode-2024b-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-h8d8f337_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uriparser-0.9.8-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xerces-c-3.2.5-h595f43b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-glproto-1.4.17-h86ecc28_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.14-hf897c2e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.1.3-h68df207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.0-h57736b2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h86ecc28_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py312h3f48502_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zeromq-4.3.5-h8046b5e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h68df207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.0-h00cdb27_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.31-hc27b277_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.4-h41dd001_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.28-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.19-h41dd001_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.3-h40a8fc1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.10-hf5a2c8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.18-hc3cb426_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.6-h3acc7b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.6-hd16c091_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.19-h41dd001_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.20-h41dd001_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.28.3-hdde83a9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.407-h0455a66_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.13.0-hd01fc5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.8.0-h13ea094_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.12.0-hfde595f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.7.0-hcf3b6fd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bullet-cpp-3.25-py312h02baea5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.33.1-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.8.0-h2664225_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-hf67d63f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4208deb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.4.1-h793ed5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17-17.0.6-default_h146c034_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-17.0.6-default_h360f5da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-18-18.1.8-default_h5c12605_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-18.1.8-default_h5c12605_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-17.0.6-he47c785_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-17.0.6-h54d7cd3_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-17.0.6-default_h360f5da_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-17.0.6-h50f59cd_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-17.0.6-h54d7cd3_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cli11-2.4.1-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.30.4-hfbcbe4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/collada-dom-2.5.0-h0e0a781_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-17.0.6-h856b3c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-17.0.6-h832e737_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compilers-1.8.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/console_bridge-1.0.2-h3e96240_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cppzmq-4.10.0-h42a7a8d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.8.0-he8d86c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dartsim-cpp-6.14.5-h6521eda_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-h613754d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fd-find-10.2.0-h3bba108_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.2-gpl_he9820c9_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flann-1.9.2-hd2cfa1e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h420ef59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fortran-compiler-1.8.0-hc3477c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freeimage-3.18.0-hf268909_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran-13.2.0-h1ca8e4b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_impl_osx-arm64-13.2.0-h252ada1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_osx-arm64-13.2.0-h57527a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.1-h4821c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.1-he5bafa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_hec07895_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imgui-1.91.2-h81f08e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/isl-0.26-imath32_h347afa1_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsoncpp-1.9.6-h7b3277c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.3-h8edbb62_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h39a299f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-hc81425b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.4-h83d404f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libccd-double-2.1-h9a09cb3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp18.1-18.1.8-default_h5c12605_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.0-default_h17c4df3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.0-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-17.0.6-h86353a2_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.21-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.9.2-hce30654_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.9.2-h3535123_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-fits-3.9.2-h248c7bc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.9.2-h6d3d72d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.9.2-h3847bb8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.9.2-h2def128_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.9.2-hd61e619_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-kea-3.9.2-h7b2de0b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.9.2-h5e0d008_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pdf-3.9.2-h587d690_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pg-3.9.2-h147afc8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-postgisraster-3.9.2-h147afc8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-tiledb-3.9.2-h27a95ea_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-xls-3.9.2-habc1c91_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-arm64-13.2.0-h5d7a38c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.1-h4821c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.29.0-hfa33a2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.29.0-h90fd6fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.2-h9c18a4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-cmake3-3.5.3-h00cdb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-cmake4-4.0.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-common6-6.0.0-h878ae6e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-fuel-tools10-10.0.0-h4085c6b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-gui9-9.0.0-h3e282c6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-math8-8.0.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-msgs11-11.0.0-h05e06dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-physics8-8.0.0-hedffbc7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-plugin3-3.0.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-rendering9-9.0.0-hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sensors9-9.0.0-h5d09c95_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sim9-9.0.0-py312he507933_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-tools2-2.0.1-hce4b3f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-transport14-14.0.0-h2790677_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-utils2-2.2.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-utils3-3.0.0-h076fc8e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.1-default_h7685b71_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-24_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm18-18.1.8-h5090b49_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.1-hbfa8675_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_he469be0_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libode-0.16.2-py312h20a0b95_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h517c56d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312haa779ad_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-h49f535f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-h49f535f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-h8a2fcec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-h8a2fcec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h868cbb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h868cbb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-hf4ed89a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-hf4ed89a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h94307f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-h671472c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hc39d83c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libraw-0.21.3-hee66ff5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h51b9955_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsdformat15-15.0.0-h5ba3470_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.1-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h9c1d414_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.49.0-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h01dff8b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h5e6703a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.1-hfc4440f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.0-hba312e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-17.0.6-h5090b49_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h5246617_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-hb96318c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.8.0-py312h857dc0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.105-hd1ce637_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/octomap-1.9.8-hffc8910_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-1.10.12.1-h02a7885_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ogre-next-2.3.3-h167f6a0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-hab01212_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openscenegraph-3.6.5-hf1a0bd2_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pagmo-2.19.1-h95c0c50_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre-8.45-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.08.0-h37b219d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.4-ha29bbc8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.6-h739c21a_2_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-h1c95b31_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruby-3.3.3-h57ff7e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.14.1-h6d8af72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.46.1-h3b4c4e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.2.1-ha39b806_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/swig-4.2.1-hd6c3d49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.13.0-h7b3277c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.26.1-hb36ea6a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-10.0.0-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2024b-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-4.0.1-h922ef61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom_headers-1.1.2-h7b3277c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libice-1.1.1-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libsm-1.2.4-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxaw-1.0.14-h3422bc3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxmu-1.1.3-h99b78c6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxpm-3.5.17-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxt-1.3.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py312ha99ad27_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h64debc3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zziplib-0.13.69-h57f5043_2.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.0-he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.31-hce3b56f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.4-hf1fc857_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.28-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.19-hf1fc857_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.3-hd0ca3c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.10-heca9ddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h3831a8d_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.6-hf27581b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.6-h56e9fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-hf1fc857_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.20-hf1fc857_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.28.3-hd65be8e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.407-h25dd3c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.13.0-haf5610f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h148e6f0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.12.0-hf03c1c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.7.0-h148e6f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hd2403df_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.33.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.8.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.1-hc2ea260_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-format-18.1.8-default_hec7ea82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/clangdev-5.0.0-flang_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cli11-2.4.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.30.4-h400e5d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/collada-dom-2.5.0-h1bf3522_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/compilers-1.8.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/console_bridge-1.0.2-h5362a0b_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cppzmq-4.10.0-h42135b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.8.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.14.5-hb31bbbe_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dlfcn-win32-1.4.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.3-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-he22821c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fd-find-10.2.0-h8b8d39b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.2-gpl_h9673905_705.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flang-5.0.0-he025d50_20180525.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flang_win-64-5.0.0-h13ae965_20180526.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-hf9aaf8f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.0.2-h7f575de_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fortran-compiler-1.8.0-h9655429_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freeimage-3.18.0-h977226e_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.1-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.1-h4394cf3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.15.2-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imgui-1.91.2-hecf2515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsoncpp-1.9.6-hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-24_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-24_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libccd-double-2.1-h63175ca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.0-default_ha5278ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.21-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.2-h57928b3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.2-hf78aeaf_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.2-h0a0b71e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.2-hd2a089b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.2-h430f241_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.2-had131a1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.2-hed4c6cb_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.2-h95b1a77_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.2-h55e78d3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.2-ha1c78db_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.2-ha693a0f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.2-ha693a0f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.2-hb8b5d01_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.2-hd0e23a6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.1-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.29.0-h5e7cea3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.29.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake3-3.5.3-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake4-4.0.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-common6-6.0.0-h6496e4a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-fuel-tools10-10.0.0-h4050545_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-gui9-9.0.0-he8cbe1f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-math8-8.0.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.0.0-hf246b6b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.0.0-hddb745a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.0.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.0.0-he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.0.0-h944dae9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-hf2d66a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-tools2-2.0.1-h9fbcf1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.0.0-hc8978a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils2-2.2.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.0.0-hb990982_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-24_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-24_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h53d5487_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py310h826334f_606.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-hdeef14f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-hdeef14f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-h7c40eac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.4-hab9416b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h47a098d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libraw-0.21.3-h0f5434b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.0.0-hf143461_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
@@ -4454,12 +5761,12 @@ packages:
 - kind: conda
   name: dartsim-cpp
   version: 6.14.5
-  build: h198e952_6
-  build_number: 6
+  build: h198e952_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dartsim-cpp-6.14.5-h198e952_6.conda
-  sha256: 7b711cc6907c6f75e5ba4fb5ea3465be1773915e44e28541429deba136ebfe28
-  md5: 555fe480498c53ed11a8bd6f29f5ee84
+  url: https://conda.anaconda.org/conda-forge/linux-64/dartsim-cpp-6.14.5-h198e952_7.conda
+  sha256: 173c948a71b4b7394b198a4540c65e642762a29f73f221b7a53fb116055004cd
+  md5: 3d4427d07bf335e586f2f7ee1daeea4a
   depends:
   - __glibc >=2.17,<3.0.a0
   - assimp >=5.4.3,<5.4.4.0a0
@@ -4481,17 +5788,18 @@ packages:
   - tinyxml2 >=10.0.0,<11.0a0
   - urdfdom >=4.0.1,<4.1.0a0
   license: BSD-2-Clause
-  size: 14656981
-  timestamp: 1727743640455
+  license_family: BSD
+  size: 14685198
+  timestamp: 1727782514501
 - kind: conda
   name: dartsim-cpp
   version: 6.14.5
-  build: h6521eda_6
-  build_number: 6
+  build: h6521eda_7
+  build_number: 7
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dartsim-cpp-6.14.5-h6521eda_6.conda
-  sha256: 33dacbe174c28cb0b76947ababa28b85d6469ba74fdacfe812d14622fa7f28ec
-  md5: bd3ec30b79ff32426adf398610df5f0b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dartsim-cpp-6.14.5-h6521eda_7.conda
+  sha256: aa7949271833bc34eb59b835ea9de27b879c77f332f4d7ca9923777e338b083a
+  md5: de83e341ef4eca3d694fde73082ce053
   depends:
   - __osx >=11.0
   - assimp >=5.4.3,<5.4.4.0a0
@@ -4511,17 +5819,18 @@ packages:
   - tinyxml2 >=10.0.0,<11.0a0
   - urdfdom >=4.0.1,<4.1.0a0
   license: BSD-2-Clause
-  size: 13019285
-  timestamp: 1727741536221
+  license_family: BSD
+  size: 13185974
+  timestamp: 1727781601208
 - kind: conda
   name: dartsim-cpp
   version: 6.14.5
-  build: hb31bbbe_6
-  build_number: 6
+  build: hb31bbbe_7
+  build_number: 7
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.14.5-hb31bbbe_6.conda
-  sha256: 1395cd466a765c1317e6ef995cefea9d735885f4ea05225f0fde14dbdd9a7041
-  md5: ac383051726cb310a4a0e46cb969bb10
+  url: https://conda.anaconda.org/conda-forge/win-64/dartsim-cpp-6.14.5-hb31bbbe_7.conda
+  sha256: 31d6d740052a92211422429e707e6b092035dfa8deae6e1d6cc7f01f1079c653
+  md5: 7bcedd63aeb25d82efbe9abe5585083d
   depends:
   - assimp >=5.4.3,<5.4.4.0a0
   - bullet-cpp >=3.25,<3.26.0a0
@@ -4543,17 +5852,18 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
-  size: 28902106
-  timestamp: 1727751197467
+  license_family: BSD
+  size: 29062173
+  timestamp: 1727790100514
 - kind: conda
   name: dartsim-cpp
   version: 6.14.5
-  build: hf7109e4_6
-  build_number: 6
+  build: hf7109e4_7
+  build_number: 7
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dartsim-cpp-6.14.5-hf7109e4_6.conda
-  sha256: 177ba9d46190af35c37cbcc4f21a75860215dccf589025c6879038062ce13847
-  md5: d83db86292c1e4e6e60c2f8852959df1
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dartsim-cpp-6.14.5-hf7109e4_7.conda
+  sha256: 498d82312abb37bfd70acbfac4ff49f307a4c4021cf89f86805dd5d6d85605ee
+  md5: 0771137fae92ba8d25fbc16d6d37a0d8
   depends:
   - assimp >=5.4.3,<5.4.4.0a0
   - bullet-cpp >=3.25,<3.26.0a0
@@ -4574,8 +5884,9 @@ packages:
   - tinyxml2 >=10.0.0,<11.0a0
   - urdfdom >=4.0.1,<4.1.0a0
   license: BSD-2-Clause
-  size: 16900830
-  timestamp: 1727742778501
+  license_family: BSD
+  size: 16340769
+  timestamp: 1727782948904
 - kind: conda
   name: dav1d
   version: 1.2.1
@@ -8234,6 +9545,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
+  license_family: APACHE
   size: 87736
   timestamp: 1727732609299
 - kind: conda
@@ -12477,6 +13789,68 @@ packages:
   size: 205005
   timestamp: 1715098992968
 - kind: conda
+  name: libgz-cmake4
+  version: 4.0.0
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.0.0-h5888daf_0.conda
+  sha256: 75a96f98d473ffa8cb93918a6bf1c86b31a8792698fd5b7d4ab51e8eb08b9ee0
+  md5: dca155882e36eb26c08c959c839ef2a8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 201339
+  timestamp: 1727326089545
+- kind: conda
+  name: libgz-cmake4
+  version: 4.0.0
+  build: h5ad3122_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.0.0-h5ad3122_0.conda
+  sha256: 2c87e69c0f1e0034d720407538cdc2cffcf45ce62a425a729c95d9dada975b97
+  md5: 0bd5c482719391017a022e0ec2720cd0
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 201451
+  timestamp: 1727326092247
+- kind: conda
+  name: libgz-cmake4
+  version: 4.0.0
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-cmake4-4.0.0-he0c23c2_0.conda
+  sha256: 4797777aa73add559ca9178be0b399a4e2ed0329220e917b5cc3ecefa7b20894
+  md5: 0a04d076886e173d2f7a5ce45de86988
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 201925
+  timestamp: 1727326231462
+- kind: conda
+  name: libgz-cmake4
+  version: 4.0.0
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-cmake4-4.0.0-hf9b8971_0.conda
+  sha256: a902a553d27f5ee16e38bbcb444362199e9f98c4078f290fbe6e2fcedc8b6b53
+  md5: d7ce82d06d3eb747e8bf5e7f4a05c2f5
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: APACHE
+  size: 202018
+  timestamp: 1727326133610
+- kind: conda
   name: libgz-common5
   version: 5.6.0
   build: h4b5afe7_7
@@ -12589,6 +13963,221 @@ packages:
   license_family: APACHE
   size: 660394
   timestamp: 1727125907192
+- kind: conda
+  name: libgz-common6
+  version: 6.0.0
+  build: h6496e4a_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-common6-6.0.0-h6496e4a_2.conda
+  sha256: 6ed86a8d00868d3899265d0eec8548402c12da73c392dfea6dd0c28cd1d5cade
+  md5: b992fc49d366fe725f7c5cc33bfa322a
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - ffmpeg >=6.1.2,<7.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libgdal >=3.9.2,<3.10.0a0
+  - libgdal-core >=3.9.2,<3.10.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 644002
+  timestamp: 1727648541887
+- kind: conda
+  name: libgz-common6
+  version: 6.0.0
+  build: h6f2e459_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-common6-6.0.0-h6f2e459_2.conda
+  sha256: 1d31181e77bbcbd3cdd8e44de2ac34e5d8dad4723695caf92601e061811fb3b3
+  md5: 075c44a2662fe2241ba4a6a42e1c08ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - ffmpeg >=7.0.2,<8.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libgcc >=13
+  - libgdal >=3.9.2,<3.10.0a0
+  - libgdal-core >=3.9.2,<3.10.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libuuid >=2.38.1,<3.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 775954
+  timestamp: 1727647844873
+- kind: conda
+  name: libgz-common6
+  version: 6.0.0
+  build: h878ae6e_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-common6-6.0.0-h878ae6e_2.conda
+  sha256: 3cb5612805480a796c137b3dd4b486ddcb97e35e50c7dd3627b222d6d0da6dd2
+  md5: ab6566a903c05213a1a080a5dc03dc25
+  depends:
+  - __osx >=11.0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - ffmpeg >=6.1.2,<7.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libcxx >=17
+  - libgdal >=3.9.2,<3.10.0a0
+  - libgdal-core >=3.9.2,<3.10.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 591394
+  timestamp: 1727647906200
+- kind: conda
+  name: libgz-common6
+  version: 6.0.0
+  build: hd965c31_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-common6-6.0.0-hd965c31_2.conda
+  sha256: 180615299836842955d2bedbdd03a7220867102d3d86ee5cc0c5478a05add5fb
+  md5: e1dc81f9b88077cc300ab1162c5f0981
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - ffmpeg >=6.1.2,<7.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libgcc >=13
+  - libgdal >=3.9.2,<3.10.0a0
+  - libgdal-core >=3.9.2,<3.10.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libuuid >=2.38.1,<3.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 765752
+  timestamp: 1727647839774
+- kind: conda
+  name: libgz-fuel-tools10
+  version: 10.0.0
+  build: h3aa7d20_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-fuel-tools10-10.0.0-h3aa7d20_0.conda
+  sha256: bc4feba57d38f273615636ddada0e608b681906d80ea8c1da47eaf8986fd6992
+  md5: 923fe52203447a957122eeea9fa99a9a
+  depends:
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx >=13
+  - libzip >=1.11.1,<2.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 273204
+  timestamp: 1727682090255
+- kind: conda
+  name: libgz-fuel-tools10
+  version: 10.0.0
+  build: h4050545_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-fuel-tools10-10.0.0-h4050545_0.conda
+  sha256: be581370350b345bd76e66964d8097365a07275a92167ca2b8198c1b3342ea28
+  md5: febaf3fde83930168daa99b22bed6fce
+  depends:
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libzip >=1.11.1,<2.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 228624
+  timestamp: 1727682832876
+- kind: conda
+  name: libgz-fuel-tools10
+  version: 10.0.0
+  build: h4085c6b_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-fuel-tools10-10.0.0-h4085c6b_0.conda
+  sha256: 1460ee9a061f4c8c51f42a5be657fbb8519cf7d39511e3b3dc4dfbf0ea59cfeb
+  md5: f1d3ceaafaad20380ee273571d648bb4
+  depends:
+  - __osx >=11.0
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libzip >=1.11.1,<2.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 226114
+  timestamp: 1727682122127
+- kind: conda
+  name: libgz-fuel-tools10
+  version: 10.0.0
+  build: h4cd16b4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-fuel-tools10-10.0.0-h4cd16b4_0.conda
+  sha256: f5bee4a594a6e9cb82da2750e819c44e59a2dcbc28b880268dabe17ffb614d05
+  md5: b14bfa9ff723e80abd0138ac3a4b2f51
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx >=13
+  - libzip >=1.11.1,<2.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 280854
+  timestamp: 1727682025610
 - kind: conda
   name: libgz-fuel-tools9
   version: 9.0.3
@@ -12822,6 +14411,134 @@ packages:
   size: 582258
   timestamp: 1724590965888
 - kind: conda
+  name: libgz-gui9
+  version: 9.0.0
+  build: h3e282c6_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-gui9-9.0.0-h3e282c6_3.conda
+  sha256: 4a3a04156be5cf2f672450feabae78f3237fdf175183e664531be48f8ae9b4a5
+  md5: 1815224e16408c6201e787f24dd1d39d
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 622402
+  timestamp: 1727816221
+- kind: conda
+  name: libgz-gui9
+  version: 9.0.0
+  build: h595855f_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-gui9-9.0.0-h595855f_3.conda
+  sha256: 124cea864b4217f498c99248a2749d5ee94d22586528efc1ade48b6148e327fd
+  md5: a282dc4b83333cfd41038b53bdaffc31
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 770690
+  timestamp: 1727816305048
+- kind: conda
+  name: libgz-gui9
+  version: 9.0.0
+  build: ha98a267_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-gui9-9.0.0-ha98a267_3.conda
+  sha256: b9f8a1d0adc3d150d2b375b3c189226d5efae5994267cd0e5aea3bde5aa4abca
+  md5: ddbbe4ea1e68991e215eb02753035462
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 759940
+  timestamp: 1727816087983
+- kind: conda
+  name: libgz-gui9
+  version: 9.0.0
+  build: he8cbe1f_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-gui9-9.0.0-he8cbe1f_3.conda
+  sha256: 01105d87ffbd51fe83e7a711388c9f892c2645618fcf5b73287d83c29feecef4
+  md5: fc3c6c609304405c806d0c19d508e4ec
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 596363
+  timestamp: 1727817277811
+- kind: conda
   name: libgz-math7
   version: 7.5.1
   build: h5888daf_0
@@ -12895,6 +14612,80 @@ packages:
   license_family: APACHE
   size: 223223
   timestamp: 1724475997111
+- kind: conda
+  name: libgz-math8
+  version: 8.0.0
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.0.0-h5888daf_0.conda
+  sha256: b51e31dca5ff83367e31ac5d7a6bf47f0392e0d5849af21faaa6346fc7b2447c
+  md5: c5090a3498ad5d1e4e7c22d2232a453c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 268425
+  timestamp: 1727436458841
+- kind: conda
+  name: libgz-math8
+  version: 8.0.0
+  build: h5ad3122_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.0.0-h5ad3122_0.conda
+  sha256: 349aa60787dd28971864e2be3a554558c8bf3c7c5e37641863c07b1bc02b2ed5
+  md5: e8e8904e21f24c5b2d67a040d4d371c3
+  depends:
+  - eigen
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 266421
+  timestamp: 1727436537166
+- kind: conda
+  name: libgz-math8
+  version: 8.0.0
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-math8-8.0.0-he0c23c2_0.conda
+  sha256: 53a19e5df7351d0721a422c4fd2abe0711430c1a60f6ffb8984078f36e8c1c9e
+  md5: 8b3c99e4ea854c8b679803f7da334d1d
+  depends:
+  - eigen
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 233797
+  timestamp: 1727437256517
+- kind: conda
+  name: libgz-math8
+  version: 8.0.0
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-math8-8.0.0-hf9b8971_0.conda
+  sha256: 91d44965360f8f429d08edeb513a41c89885e320c55ee0fe6337e5e988cf17b5
+  md5: 635f4d8eed615daf48ee7b0bfb57990a
+  depends:
+  - __osx >=11.0
+  - eigen
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222295
+  timestamp: 1727436498487
 - kind: conda
   name: libgz-msgs10
   version: 10.3.0
@@ -12986,6 +14777,105 @@ packages:
   license_family: APACHE
   size: 1045727
   timestamp: 1724624650802
+- kind: conda
+  name: libgz-msgs11
+  version: 11.0.0
+  build: h05e06dd_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-msgs11-11.0.0-h05e06dd_2.conda
+  sha256: dbb9c70faae6299ddc52349687d1333148c3cda6010faeab41a3608f3c4897c6
+  md5: 5c4665339176e9def15808257f3668d1
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - python
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 999447
+  timestamp: 1727687456288
+- kind: conda
+  name: libgz-msgs11
+  version: 11.0.0
+  build: h7cb8037_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-msgs11-11.0.0-h7cb8037_2.conda
+  sha256: 6ca07b8edfd97cde3413065a7e83d31af5d502005440eb205a774b4b6868acba
+  md5: baf96057817826f3713f1c9642139c44
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx >=13
+  - python
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1178643
+  timestamp: 1727686612628
+- kind: conda
+  name: libgz-msgs11
+  version: 11.0.0
+  build: hbbdfe00_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-msgs11-11.0.0-hbbdfe00_2.conda
+  sha256: 3875ecccf2ecdd6203dfa95edf5589712150a972004b13cbf849ba60dc13d680
+  md5: 21587a2b2bbbfa3d1d9a2607331420d1
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx >=13
+  - python
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1160336
+  timestamp: 1727687490803
+- kind: conda
+  name: libgz-msgs11
+  version: 11.0.0
+  build: hf246b6b_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-msgs11-11.0.0-hf246b6b_2.conda
+  sha256: 4b3f0c372317be058fdaf8c103c1e3bfddfef207e8d4cfeaf1c9ece3121f0285
+  md5: 8b8513652fc7720429072cdb925e3285
+  depends:
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - python
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2012204
+  timestamp: 1727687110929
 - kind: conda
   name: libgz-physics7
   version: 7.3.0
@@ -13093,6 +14983,112 @@ packages:
   size: 2961499
   timestamp: 1727635978156
 - kind: conda
+  name: libgz-physics8
+  version: 8.0.0
+  build: h927b50a_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-physics8-8.0.0-h927b50a_2.conda
+  sha256: 2c089e72cc7562d2a280c73522f4c6ab6533be4985df2f100554fce19ae6b54e
+  md5: 13aefcdbb5becfc895af89fdd08fb859
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - bullet-cpp >=3.25,<3.26.0a0
+  - dartsim-cpp >=6.14.5,<6.15.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libode >=0.16.2,<0.16.3.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 835227
+  timestamp: 1727707056012
+- kind: conda
+  name: libgz-physics8
+  version: 8.0.0
+  build: hb9befc3_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-physics8-8.0.0-hb9befc3_2.conda
+  sha256: 91a97ce529a93cbfdac81ed79ac3958a67dfabd0a843301fe2200f8b033f2692
+  md5: ac88399cae416506cebc8f6cc486f951
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - bullet-cpp >=3.25,<3.26.0a0
+  - dartsim-cpp >=6.14.5,<6.15.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libode >=0.16.2,<0.16.3.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 801783
+  timestamp: 1727700543922
+- kind: conda
+  name: libgz-physics8
+  version: 8.0.0
+  build: hddb745a_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-physics8-8.0.0-hddb745a_2.conda
+  sha256: c7bf3fc76311a92ff178cd748db66d47e4fd807a155cbedf8519a6689e1b750b
+  md5: 818bcc40fbd7b9bc69121634bfb9f1fe
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - bullet-cpp >=3.25,<3.26.0a0
+  - dartsim-cpp >=6.14.5,<6.15.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libode >=0.16.2,<0.16.3.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3532319
+  timestamp: 1727703012455
+- kind: conda
+  name: libgz-physics8
+  version: 8.0.0
+  build: hedffbc7_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-physics8-8.0.0-hedffbc7_2.conda
+  sha256: 5b21e151aa1d1e52409bcabde6cd31cfb40d23b5e233c5df1a29258f804b17f4
+  md5: fb384d2797d3e45369b95a6e7caab419
+  depends:
+  - __osx >=11.0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - bullet-cpp >=3.25,<3.26.0a0
+  - dartsim-cpp >=6.14.5,<6.15.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libode >=0.16.2,<0.16.3.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 976073
+  timestamp: 1727701297999
+- kind: conda
   name: libgz-plugin2
   version: 2.0.3
   build: h5888daf_1
@@ -13172,63 +15168,144 @@ packages:
   size: 206614
   timestamp: 1724584427514
 - kind: conda
-  name: libgz-rendering8
-  version: 8.2.0
+  name: libgz-plugin3
+  version: 3.0.0
   build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-rendering8-8.2.0-h5888daf_0.conda
-  sha256: ce7b80f698caa775c7109003b9ed0a7eeea1803dd081fa10a153b82a69e53aba
-  md5: 646bdaaa3f1ebd10273b6cdd6b361eaa
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-plugin3-3.0.0-h5888daf_0.conda
+  sha256: 1a91928b5a537eee07998e4d694867aa3280985b0d7ea89d972d7d93e674df0f
+  md5: 0375e66788b00aa5ef1ea272260cf992
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=13
-  - libglu
-  - libgz-common5 >=5.6.0,<6.0a0
-  - libgz-math7 >=7.5.1,<8.0a0
-  - libgz-plugin2 >=2.0.3,<3.0a0
-  - libgz-utils2 >=2.2.0,<3.0a0
-  - libstdcxx-ng >=13
-  - ogre >=1.10.12.1,<1.11.0a0
-  - ogre-next >=2.3.3,<2.3.4.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 4603548
-  timestamp: 1724658423750
+  size: 233298
+  timestamp: 1727482332714
 - kind: conda
-  name: libgz-rendering8
-  version: 8.2.0
+  name: libgz-plugin3
+  version: 3.0.0
   build: h5ad3122_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-rendering8-8.2.0-h5ad3122_0.conda
-  sha256: 39366520d47ba31eea1d85dffbc8ed6f3496fff65cbf8c42c94efc962d684c98
-  md5: 63990d19ec8d01f6f8ccac8aae4b3c2c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-plugin3-3.0.0-h5ad3122_0.conda
+  sha256: c81add2051b479fbeccaabb93795f85ccb34a609560ce24b30ed0e8582fc9faa
+  md5: 793fe209a37164cedaa8f30ca18d9c76
   depends:
-  - libgcc-ng >=13
-  - libglu
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 228583
+  timestamp: 1727482404067
+- kind: conda
+  name: libgz-plugin3
+  version: 3.0.0
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-plugin3-3.0.0-he0c23c2_0.conda
+  sha256: e2eb985af040b376f5564c4457157f92345b2847cc6f29b22d4ff10ce938d234
+  md5: b8ce7700c84f2599d70fa176325d2787
+  depends:
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 235399
+  timestamp: 1727483017686
+- kind: conda
+  name: libgz-plugin3
+  version: 3.0.0
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-plugin3-3.0.0-hf9b8971_0.conda
+  sha256: 33622cc1071ff95102dffe2c44211b1bf1a639a6d2bf6c37d2f033e624ec052b
+  md5: a523cc3461658f44416faf3f38fe94b1
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 217465
+  timestamp: 1727482537807
+- kind: conda
+  name: libgz-rendering8
+  version: 8.2.0
+  build: h5888daf_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-rendering8-8.2.0-h5888daf_1.conda
+  sha256: 9c9416d173cd733b16fb452bb35e2b34fa62101a5d9789f009bc334fc0623ec3
+  md5: 4abdc0ac3195a7a96879078303bc7aef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libglx >=1.7.0,<2.0a0
   - libgz-common5 >=5.6.0,<6.0a0
   - libgz-math7 >=7.5.1,<8.0a0
   - libgz-plugin2 >=2.0.3,<3.0a0
   - libgz-utils2 >=2.2.0,<3.0a0
-  - libstdcxx-ng >=13
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
   - ogre >=1.10.12.1,<1.11.0a0
   - ogre-next >=2.3.3,<2.3.4.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libx11
+  - xorg-libxext
   license: Apache-2.0
-  license_family: APACHE
-  size: 4337531
-  timestamp: 1724658189843
+  size: 4943511
+  timestamp: 1727859284780
 - kind: conda
   name: libgz-rendering8
   version: 8.2.0
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering8-8.2.0-he0c23c2_0.conda
-  sha256: d9f56b60c48b17674cdcf8efb280e6530b6392d1b61012730ba5e8c126263c36
-  md5: 29a52d8f4cbf4655fbe8ca05c1d549c3
+  build: h5ad3122_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-rendering8-8.2.0-h5ad3122_1.conda
+  sha256: 8784d38a981a63e7cc9ddb169ef199b8635ce4e6034a142cd11e61fbc2656f5f
+  md5: 7e63d012c630ec2a827ca7d8d9943b15
   depends:
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libglx >=1.7.0,<2.0a0
+  - libgz-common5 >=5.6.0,<6.0a0
+  - libgz-math7 >=7.5.1,<8.0a0
+  - libgz-plugin2 >=2.0.3,<3.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  - ogre-next >=2.3.3,<2.3.4.0a0
+  - xorg-libx11
+  - xorg-libxext
+  license: Apache-2.0
+  size: 4998699
+  timestamp: 1727859574722
+- kind: conda
+  name: libgz-rendering8
+  version: 8.2.0
+  build: he0c23c2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering8-8.2.0-he0c23c2_1.conda
+  sha256: 6cdc2d31c5078e90acaa081d791fe0df30c96ad9b93a3714a9f7930353e4a579
+  md5: 3559de88d15eb0326db80d64c85ec8aa
+  depends:
+  - dlfcn-win32 >=1.4.1,<2.0a0
   - libgz-common5 >=5.6.0,<6.0a0
   - libgz-math7 >=7.5.1,<8.0a0
   - libgz-plugin2 >=2.0.3,<3.0a0
@@ -13239,17 +15316,17 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
-  license_family: APACHE
-  size: 4141254
-  timestamp: 1724659087149
+  size: 3938461
+  timestamp: 1727860404150
 - kind: conda
   name: libgz-rendering8
   version: 8.2.0
-  build: hf9b8971_0
+  build: hf9b8971_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-rendering8-8.2.0-hf9b8971_0.conda
-  sha256: 9c0986b5c1fabf5f82ce0242209be5dcbefdd63e28108fdb0826960afc89b9ab
-  md5: e68ce3ee0104a8520cf13a51398d4d35
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-rendering8-8.2.0-hf9b8971_1.conda
+  sha256: 920dc38fc6fba1354285571868034be71078a5821e63196c57b28562ecb65eb6
+  md5: c369e6ebf4f276ac7518dfeb731dc0e9
   depends:
   - __osx >=11.0
   - libcxx >=17
@@ -13259,12 +15336,104 @@ packages:
   - libgz-utils2 >=2.2.0,<3.0a0
   - ogre >=1.10.12.1,<1.11.0a0
   - ogre-next >=2.3.3,<2.3.4.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libx11
+  - xorg-libxext
   license: Apache-2.0
-  license_family: APACHE
-  size: 3410067
-  timestamp: 1724658355977
+  size: 3583301
+  timestamp: 1727859567817
+- kind: conda
+  name: libgz-rendering9
+  version: 9.0.0
+  build: h5888daf_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-rendering9-9.0.0-h5888daf_1.conda
+  sha256: 18c5346bdce92dc50dcb123e6f83f9dd608ea4f75ab4150bdd7ad66e1dfc5bb9
+  md5: 31b59d3b0d3692d3a334fe7c86b9c1f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libglx >=1.7.0,<2.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  - ogre-next >=2.3.3,<2.3.4.0a0
+  license: Apache-2.0
+  size: 5673064
+  timestamp: 1727856886632
+- kind: conda
+  name: libgz-rendering9
+  version: 9.0.0
+  build: h5ad3122_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-rendering9-9.0.0-h5ad3122_1.conda
+  sha256: 2c33f9f36841d5063406aba4535cf54954f8b16ad8f3998fea1b7bc609ab0371
+  md5: 87904e4ec4e6f94f78dde24c8f8828f8
+  depends:
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libglx >=1.7.0,<2.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  - ogre-next >=2.3.3,<2.3.4.0a0
+  license: Apache-2.0
+  size: 5240557
+  timestamp: 1727856846283
+- kind: conda
+  name: libgz-rendering9
+  version: 9.0.0
+  build: he0c23c2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-rendering9-9.0.0-he0c23c2_1.conda
+  sha256: b8afc1bb6a0e70ac6c4ccbba5ab1055cb38f19109161644f1439f784a832cabe
+  md5: eb0883db76aa7bcdfc86f8da1990eb02
+  depends:
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  - ogre-next >=2.3.3,<2.3.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  size: 4485421
+  timestamp: 1727857978456
+- kind: conda
+  name: libgz-rendering9
+  version: 9.0.0
+  build: hf9b8971_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-rendering9-9.0.0-hf9b8971_1.conda
+  sha256: 8043fd8ca8198d4d6c543a33afb1aee1a7c71aa2fd94651867b01c577389e4f2
+  md5: 68aa2a9aecb71f52fdb25da4db735d22
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  - ogre-next >=2.3.3,<2.3.4.0a0
+  license: Apache-2.0
+  size: 4607462
+  timestamp: 1727856710607
 - kind: conda
   name: libgz-sensors8
   version: 8.2.0
@@ -13377,67 +15546,331 @@ packages:
   size: 476120
   timestamp: 1724587904458
 - kind: conda
-  name: libgz-sim8
-  version: 8.3.0
-  build: h81317a9_0
+  name: libgz-sensors9
+  version: 9.0.0
+  build: h5d09c95_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sensors9-9.0.0-h5d09c95_3.conda
+  sha256: 4fa2056e648130ea3c76bd149065a4a8e7ea4a468aa5ad184968d58ee0e6a375
+  md5: 347099aff8186260b5aeca76efa7d344
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 382741
+  timestamp: 1727813832032
+- kind: conda
+  name: libgz-sensors9
+  version: 9.0.0
+  build: h8301ccf_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-sim8-8.3.0-h81317a9_0.conda
-  sha256: 6ee371d40802ff2fbe9970882bcb380ea8951bcfad817e0b2b3c2828d395ce46
-  md5: 850a5d131a52d485d17e8a51d665bda1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-sensors9-9.0.0-h8301ccf_3.conda
+  sha256: a0af9e0d60adcd1bdfae1a839b088fc1f9103ff750855196d20f5b81993fe841
+  md5: 88c49f9a9f655546a42857bd6eb5950b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 462249
+  timestamp: 1727813789418
+- kind: conda
+  name: libgz-sensors9
+  version: 9.0.0
+  build: h944dae9_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sensors9-9.0.0-h944dae9_3.conda
+  sha256: 1e45afbfc3f00c4081edc537253fa0fb847333b250a14145aa54f240c4d08832
+  md5: 3b8a6a093a2bf8ecce60b79a71424718
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libgz-cmake3 >=3.5.2,<4.0a0
-  - libgz-common5 >=5.5.1,<6.0a0
-  - libgz-fuel-tools9 >=9.0.3,<10.0a0
-  - libgz-gui8 >=8.0.0,<9.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-msgs10 >=10.1.2,<11.0a0
-  - libgz-physics7 >=7.0.0,<8.0a0
-  - libgz-plugin2 >=2.0.3,<3.0a0
-  - libgz-rendering8 >=8.1.1,<9.0a0
-  - libgz-sensors8 >=8.0.0,<9.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-transport13 >=13.2.0,<14.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsdformat14 >=14.0.0,<15.0a0
-  - libstdcxx-ng >=12
+  - libsdformat15 >=15.0.0,<16.0a0
+  - ogre >=1.10.12.1,<1.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 392478
+  timestamp: 1727814786190
+- kind: conda
+  name: libgz-sensors9
+  version: 9.0.0
+  build: hcd0cff2_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sensors9-9.0.0-hcd0cff2_3.conda
+  sha256: e59035268e320f171cbdbb606199d8b0a72f31ddd681893ae64d8765adc9a1f1
+  md5: 665d90a1305752dd3321a00e53108d45
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - libstdcxx >=13
+  - ogre >=1.10.12.1,<1.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 460249
+  timestamp: 1727813930043
+- kind: conda
+  name: libgz-sim8
+  version: 8.6.0
+  build: hb16c8d3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-sim8-8.6.0-hb16c8d3_0.conda
+  sha256: ea89a5979a6d803e67ddb13d48b6a5a86d34eb8e097c6953d796e713a65c5faa
+  md5: 91ad8f157475304830a274f959b0fae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake3 >=3.5.3,<4.0a0
+  - libgz-common5 >=5.6.0,<6.0a0
+  - libgz-fuel-tools9 >=9.0.3,<10.0a0
+  - libgz-gui8 >=8.1.1,<9.0a0
+  - libgz-math7 >=7.5.1,<8.0a0
+  - libgz-msgs10 >=10.3.0,<11.0a0
+  - libgz-physics7 >=7.3.0,<8.0a0
+  - libgz-plugin2 >=2.0.3,<3.0a0
+  - libgz-rendering8 >=8.2.0,<9.0a0
+  - libgz-sensors8 >=8.2.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport13 >=13.4.0,<14.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat14 >=14.5.0,<15.0a0
+  - libstdcxx >=13
   - pybind11-abi 4
   - python_abi 3.12.* *_cp312
   - qt-main >=5.15.8,<5.16.0a0
   - tinyxml2 >=10.0.0,<11.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: Apache-2.0
-  license_family: APACHE
-  size: 12149569
-  timestamp: 1713970246455
+  size: 12275507
+  timestamp: 1727860548127
 - kind: conda
   name: libgz-sim8
-  version: 8.3.0
-  build: hea5eaeb_0
+  version: 8.6.0
+  build: hf2d66a4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.3.0-hea5eaeb_0.conda
-  sha256: 398599b73ca14ccb6a0b0686c77c4adec8ae6bf9db12975b56b2eb82e710c2fb
-  md5: 8aba31c925109c58e3ff3ab7f383ed30
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sim8-8.6.0-hf2d66a4_0.conda
+  sha256: bf40a5620587f0545202e8153c9de03a40cfdf68d73d43148fde74dfe9e6fd7a
+  md5: acdddeeb1f9939ad07b314eb7e132a12
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgz-cmake3 >=3.5.2,<4.0a0
-  - libgz-common5 >=5.5.1,<6.0a0
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgz-cmake3 >=3.5.3,<4.0a0
+  - libgz-common5 >=5.6.0,<6.0a0
   - libgz-fuel-tools9 >=9.0.3,<10.0a0
-  - libgz-gui8 >=8.0.0,<9.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-msgs10 >=10.1.2,<11.0a0
-  - libgz-physics7 >=7.1.0,<8.0a0
+  - libgz-gui8 >=8.1.1,<9.0a0
+  - libgz-math7 >=7.5.1,<8.0a0
+  - libgz-msgs10 >=10.3.0,<11.0a0
+  - libgz-physics7 >=7.3.0,<8.0a0
   - libgz-plugin2 >=2.0.3,<3.0a0
-  - libgz-rendering8 >=8.1.1,<9.0a0
-  - libgz-sensors8 >=8.0.0,<9.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-transport13 >=13.2.0,<14.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
+  - libgz-rendering8 >=8.2.0,<9.0a0
+  - libgz-sensors8 >=8.2.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport13 >=13.4.0,<14.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsdformat14 >=14.0.0,<15.0a0
+  - libsdformat14 >=14.5.0,<15.0a0
+  - pybind11-abi 4
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  size: 9881119
+  timestamp: 1727860776745
+- kind: conda
+  name: libgz-sim8
+  version: 8.6.0
+  build: py312hc0bf31e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sim8-8.6.0-py312hc0bf31e_0.conda
+  sha256: c5d9d0210984fa1b44aaa188f9cfa72729f6831f69e8f3f2551bb6ea02e484f8
+  md5: f917be42ff9814b349a70fa5cb30439e
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake3 >=3.5.3,<4.0a0
+  - libgz-common5 >=5.6.0,<6.0a0
+  - libgz-fuel-tools9 >=9.0.3,<10.0a0
+  - libgz-gui8 >=8.1.1,<9.0a0
+  - libgz-math7 >=7.5.1,<8.0a0
+  - libgz-msgs10 >=10.3.0,<11.0a0
+  - libgz-physics7 >=7.3.0,<8.0a0
+  - libgz-plugin2 >=2.0.3,<3.0a0
+  - libgz-rendering8 >=8.2.0,<9.0a0
+  - libgz-sensors8 >=8.2.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport13 >=13.4.0,<14.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat14 >=14.5.0,<15.0a0
+  - libstdcxx >=13
+  - pybind11-abi 4
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: Apache-2.0
+  size: 11914996
+  timestamp: 1727860822766
+- kind: conda
+  name: libgz-sim8
+  version: 8.6.0
+  build: py312he507933_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sim8-8.6.0-py312he507933_0.conda
+  sha256: 5b552a9fb28fed2db6c0478502cc1ef414a778c4d7bff3c70392e2e39d367a43
+  md5: 3dbb4623eb1a4ff7be8acd58803e50aa
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcxx >=17
+  - libgz-cmake3 >=3.5.3,<4.0a0
+  - libgz-common5 >=5.6.0,<6.0a0
+  - libgz-fuel-tools9 >=9.0.3,<10.0a0
+  - libgz-gui8 >=8.1.1,<9.0a0
+  - libgz-math7 >=7.5.1,<8.0a0
+  - libgz-msgs10 >=10.3.0,<11.0a0
+  - libgz-physics7 >=7.3.0,<8.0a0
+  - libgz-plugin2 >=2.0.3,<3.0a0
+  - libgz-rendering8 >=8.2.0,<9.0a0
+  - libgz-sensors8 >=8.2.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport13 >=13.4.0,<14.0a0
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat14 >=14.5.0,<15.0a0
+  - pybind11-abi 4
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  license: Apache-2.0
+  size: 10306542
+  timestamp: 1727860483595
+- kind: conda
+  name: libgz-sim9
+  version: 9.0.0
+  build: hb16c8d3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-sim9-9.0.0-hb16c8d3_0.conda
+  sha256: f0083d267709b307d4cc72169dc688d2c9670ff27394178231a7f4ac7e277b0a
+  md5: 1d979dced73ae4553fe4ab689191ca83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-fuel-tools10 >=10.0.0,<11.0a0
+  - libgz-gui9 >=9.0.0,<10.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-physics8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-sensors9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
+  - libstdcxx >=13
+  - pybind11-abi 4
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - xorg-libxfixes >=6.0.0,<7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 11229759
+  timestamp: 1727796278827
+- kind: conda
+  name: libgz-sim9
+  version: 9.0.0
+  build: hf2d66a4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-sim9-9.0.0-hf2d66a4_0.conda
+  sha256: d9a8e91f69cd550d3487a514c897311d3285d9734104f45c83912b0a80f27106
+  md5: 51a412fd80700289d11cd0d4cd25923f
+  depends:
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-fuel-tools10 >=10.0.0,<11.0a0
+  - libgz-gui9 >=9.0.0,<10.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-physics8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-sensors9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
   - pybind11-abi 4
   - python_abi 3.12.* *_cp312
   - qt-main >=5.15.8,<5.16.0a0
@@ -13447,72 +15880,74 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 10897995
-  timestamp: 1713971402455
+  size: 10448020
+  timestamp: 1727797767830
 - kind: conda
-  name: libgz-sim8
-  version: 8.3.0
-  build: py312h39e8741_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sim8-8.3.0-py312h39e8741_0.conda
-  sha256: fec612bb614e723a821a68692142301af05d83c4279c34d6bb4fa1d344b2133b
-  md5: 53f087608e469b1291e69a1d93cd703c
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcxx >=16
-  - libgz-cmake3 >=3.5.2,<4.0a0
-  - libgz-common5 >=5.5.1,<6.0a0
-  - libgz-fuel-tools9 >=9.0.3,<10.0a0
-  - libgz-gui8 >=8.0.0,<9.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-msgs10 >=10.1.2,<11.0a0
-  - libgz-physics7 >=7.1.0,<8.0a0
-  - libgz-plugin2 >=2.0.3,<3.0a0
-  - libgz-rendering8 >=8.1.1,<9.0a0
-  - libgz-sensors8 >=8.0.0,<9.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-transport13 >=13.2.0,<14.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsdformat14 >=14.0.0,<15.0a0
-  - pybind11-abi 4
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 10448076
-  timestamp: 1713971922958
-- kind: conda
-  name: libgz-sim8
-  version: 8.3.0
-  build: py312hd1048e4_0
+  name: libgz-sim9
+  version: 9.0.0
+  build: py312hc0bf31e_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sim8-8.3.0-py312hd1048e4_0.conda
-  sha256: 500627e663a94c5d9d19f9fb1f27f48c013ccb6ccffd04dd371075946dad3b76
-  md5: 00088778252f5bc5d5c0ee19a9c41486
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-sim9-9.0.0-py312hc0bf31e_0.conda
+  sha256: dc91a96245367ac73583ca78d85eb911463a9642288113044bfc2de3783955e3
+  md5: a28ca5dd90a98e765ef030fe12ee7154
   depends:
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libgcc-ng >=12
-  - libgz-cmake3 >=3.5.2,<4.0a0
-  - libgz-common5 >=5.5.1,<6.0a0
-  - libgz-fuel-tools9 >=9.0.3,<10.0a0
-  - libgz-gui8 >=8.0.0,<9.0a0
-  - libgz-math7 >=7.3.0,<8.0a0
-  - libgz-msgs10 >=10.1.2,<11.0a0
-  - libgz-physics7 >=7.0.0,<8.0a0
-  - libgz-plugin2 >=2.0.3,<3.0a0
-  - libgz-rendering8 >=8.1.1,<9.0a0
-  - libgz-sensors8 >=8.0.0,<9.0a0
-  - libgz-tools2 >=2.0.0,<3.0a0
-  - libgz-transport13 >=13.2.0,<14.0a0
-  - libgz-utils2 >=2.1.0,<3.0a0
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-fuel-tools10 >=10.0.0,<11.0a0
+  - libgz-gui9 >=9.0.0,<10.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-physics8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-sensors9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libsdformat14 >=14.0.0,<15.0a0
-  - libstdcxx-ng >=12
+  - libsdformat15 >=15.0.0,<16.0a0
+  - libstdcxx >=13
+  - pybind11-abi 4
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.8,<5.16.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - xorg-libxfixes >=6.0.0,<7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 11161140
+  timestamp: 1727796736288
+- kind: conda
+  name: libgz-sim9
+  version: 9.0.0
+  build: py312he507933_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-sim9-9.0.0-py312he507933_0.conda
+  sha256: b35f71e1e98916923396ad3aaaef7e2fba37091439bf9a2646ffa8181b3962af
+  md5: 496cd260ae0bd97e3f3df71234b54e9b
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-common6 >=6.0.0,<7.0a0
+  - libgz-fuel-tools10 >=10.0.0,<11.0a0
+  - libgz-gui9 >=9.0.0,<10.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-physics8 >=8.0.0,<9.0a0
+  - libgz-plugin3 >=3.0.0,<4.0a0
+  - libgz-rendering9 >=9.0.0,<10.0a0
+  - libgz-sensors9 >=9.0.0,<10.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-transport14 >=14.0.0,<15.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsdformat15 >=15.0.0,<16.0a0
   - pybind11-abi 4
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -13520,8 +15955,8 @@ packages:
   - tinyxml2 >=10.0.0,<11.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 11710750
-  timestamp: 1713970216414
+  size: 9784886
+  timestamp: 1727796864974
 - kind: conda
   name: libgz-tools2
   version: 2.0.1
@@ -13703,6 +16138,114 @@ packages:
   size: 490664
   timestamp: 1725434255009
 - kind: conda
+  name: libgz-transport14
+  version: 14.0.0
+  build: h2790677_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-transport14-14.0.0-h2790677_2.conda
+  sha256: d80e95ac2b810a0f171b7fe83f25a08318261e84f188db41999ff2f1370e4ef3
+  md5: c777f38f80b4021a1b5a686d6187daf4
+  depends:
+  - __osx >=11.0
+  - cppzmq
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 521757
+  timestamp: 1727786814896
+- kind: conda
+  name: libgz-transport14
+  version: 14.0.0
+  build: h42e8520_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-transport14-14.0.0-h42e8520_2.conda
+  sha256: 5ccacf18f2979998824dbe9c68736de8df0bb07630518da20ab5f231f420d458
+  md5: 97b47c8292dc6af21185954d2a4c3bd1
+  depends:
+  - cppzmq
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libuuid >=2.38.1,<3.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 642408
+  timestamp: 1727786716549
+- kind: conda
+  name: libgz-transport14
+  version: 14.0.0
+  build: h5edbe1f_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-transport14-14.0.0-h5edbe1f_2.conda
+  sha256: de24be528e0d5b87334434fe9d3f5965b2793e3f5ae48b3852ecca62d61c855b
+  md5: 43116ddd23375ac721472c97e53e91e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cppzmq
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libuuid >=2.38.1,<3.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 654767
+  timestamp: 1727786602156
+- kind: conda
+  name: libgz-transport14
+  version: 14.0.0
+  build: hc8978a5_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-transport14-14.0.0-hc8978a5_2.conda
+  sha256: b488b22d8da849630c81f9bf5b3748e6ed85679349779958edc15b7c67d162f2
+  md5: 55b4c2369d7d70c99002fbe0286a97fa
+  depends:
+  - cppzmq
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-msgs11 >=11.0.0,<12.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 492190
+  timestamp: 1727787727823
+- kind: conda
   name: libgz-utils2
   version: 2.2.0
   build: h5888daf_0
@@ -13772,6 +16315,84 @@ packages:
   license_family: APACHE
   size: 55324
   timestamp: 1724612768380
+- kind: conda
+  name: libgz-utils3
+  version: 3.0.0
+  build: h076fc8e_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgz-utils3-3.0.0-h076fc8e_3.conda
+  sha256: 13db801a217c0f17bd89404dd53ec0c532cb31adc1020686d0cf1a7512910e94
+  md5: 8fa2c15ec6a9ad2393ac6ff0891dcdea
+  depends:
+  - __osx >=11.0
+  - cli11
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 65341
+  timestamp: 1727635232668
+- kind: conda
+  name: libgz-utils3
+  version: 3.0.0
+  build: h5eaaa13_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils3-3.0.0-h5eaaa13_3.conda
+  sha256: 87a261bbdfa2c355e2ec7d0648106f4db35a6b7c8d3ae581f04a85e76bb00963
+  md5: fba303bdb75d787b93ae05ea1e1040cb
+  depends:
+  - cli11
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libstdcxx >=13
+  - spdlog >=1.14.1,<1.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 70643
+  timestamp: 1727635180081
+- kind: conda
+  name: libgz-utils3
+  version: 3.0.0
+  build: h6ea83cf_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.0.0-h6ea83cf_3.conda
+  sha256: 117fb7644e6660a0f0590cdb226f288f167a7f8787212d0ff6f89fccac0789df
+  md5: b9959df549dc2468661ded32a675b91e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cli11
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libstdcxx >=13
+  - spdlog >=1.14.1,<1.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72412
+  timestamp: 1727635217839
+- kind: conda
+  name: libgz-utils3
+  version: 3.0.0
+  build: hb990982_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgz-utils3-3.0.0-hb990982_3.conda
+  sha256: b12f8f48d81980bf924fa6c7c884158834c81599e0e5638597d1a8673c2c0be7
+  md5: 625e397b0ef07be94a4f25301147710b
+  depends:
+  - cli11
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 68656
+  timestamp: 1727635669212
 - kind: conda
   name: libhwloc
   version: 2.11.1
@@ -14455,24 +17076,6 @@ packages:
 - kind: conda
   name: libllvm19
   version: 19.1.0
-  build: h2edbd07_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.0-h2edbd07_0.conda
-  sha256: 6e4a7e4951f790cbc731702781082d4779c69d566550ab5875e321a2a9557bba
-  md5: 9301bd5de261b4394c632b243bc4e96d
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 39446655
-  timestamp: 1726650266839
-- kind: conda
-  name: libllvm19
-  version: 19.1.0
   build: ha7bfdaf_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.0-ha7bfdaf_0.conda
@@ -14491,12 +17094,30 @@ packages:
   timestamp: 1726655877428
 - kind: conda
   name: libllvm19
-  version: 19.1.0
+  version: 19.1.1
+  build: h2edbd07_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.1-h2edbd07_0.conda
+  sha256: 0e10dffaecf4dae1d2d7709ce2e6de46b01ed449a4f50c8f7cc3d7c02baa9c28
+  md5: a59a8c3d47a450db483c41b0247774c8
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 39444350
+  timestamp: 1727858100775
+- kind: conda
+  name: libllvm19
+  version: 19.1.1
   build: hbfa8675_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.0-hbfa8675_0.conda
-  sha256: 2b9386e9028d9b1fda3dd075f5208c02ba8014f363ef70282aef6fda681b55d7
-  md5: d2295f79e34d0ed471148dd178b2992b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.1-hbfa8675_0.conda
+  sha256: 89e09411c36d4ee721bb7ed16b80ffe10c472f0601fa5e2d77cd0766a565967f
+  md5: 3bc8c5b0341d4e7a5d4319a16ac04a9b
   depends:
   - __osx >=11.0
   - libcxx >=17
@@ -14505,8 +17126,8 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 26856795
-  timestamp: 1726652287503
+  size: 26866856
+  timestamp: 1727857150443
 - kind: conda
   name: libmicrohttpd
   version: 1.0.1
@@ -16592,6 +19213,93 @@ packages:
   size: 846719
   timestamp: 1722935273816
 - kind: conda
+  name: libsdformat15
+  version: 15.0.0
+  build: h13c1794_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.0.0-h13c1794_0.conda
+  sha256: abfdc3423fc17f8b49e21457825e571652dfb13ed6c3075ebed8de6d32700645
+  md5: cb0e0c956d8596b84373355d518ce3d8
+  depends:
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - tinyxml2 >=10.0.0,<11.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1042463
+  timestamp: 1727527543981
+- kind: conda
+  name: libsdformat15
+  version: 15.0.0
+  build: h5ba3470_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsdformat15-15.0.0-h5ba3470_0.conda
+  sha256: f3fe84557be035357b714c42f9da0ab4fbe5209d708b512684490fbfd2839f17
+  md5: 34a77e6c742b0f9ffa759a277c606d19
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 809358
+  timestamp: 1727527337452
+- kind: conda
+  name: libsdformat15
+  version: 15.0.0
+  build: hbf83bc3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.0.0-hbf83bc3_0.conda
+  sha256: e24851b686073c7e9e9d3037ff8a3245233321079173dcc4cb46c46cc703ae7f
+  md5: addb6c99ac319f073f59124b95b928a6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - tinyxml2 >=10.0.0,<11.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1108436
+  timestamp: 1727527781165
+- kind: conda
+  name: libsdformat15
+  version: 15.0.0
+  build: hf143461_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libsdformat15-15.0.0-hf143461_0.conda
+  sha256: 1112cc4b0ed4a4adec315f23730c1fa6f9dd50d950b84a80c20955a0bef2ec24
+  md5: d57621f0efba8cc0f5e7a23e5af450a7
+  depends:
+  - dlfcn-win32 >=1.4.1,<2.0a0
+  - libgz-cmake4 >=4.0.0,<5.0a0
+  - libgz-math8 >=8.0.0,<9.0a0
+  - libgz-tools2 >=2.0.1,<3.0a0
+  - libgz-utils3 >=3.0.0,<4.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 830278
+  timestamp: 1727529418149
+- kind: conda
   name: libsndfile
   version: 1.2.2
   build: h79657aa_1
@@ -18001,21 +20709,20 @@ packages:
   size: 2667
 - kind: conda
   name: llvm-openmp
-  version: 18.1.8
-  build: hde57baf_1
-  build_number: 1
+  version: 19.1.0
+  build: hba312e6_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
-  sha256: 7a76e2932ac77e6314bfa1c4ff83f617c8260313bfed1b8401b508ed3e9d70ba
-  md5: fe89757e3cd14bb1c6ebd68dac591363
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.0-hba312e6_0.conda
+  sha256: af4b01dbfdba42141c8db6ffd2909da9df35c878654ac0149421459128e037bd
+  md5: 2f97682b9d39cf0cc42bc96d55e543cb
   depends:
   - __osx >=11.0
   constrains:
-  - openmp 18.1.8|18.1.8.*
+  - openmp 19.1.0|19.1.0.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 276263
-  timestamp: 1723605341828
+  size: 279779
+  timestamp: 1727798548683
 - kind: conda
   name: llvm-tools
   version: 17.0.6
@@ -23203,34 +25910,35 @@ packages:
   timestamp: 1727734520239
 - kind: conda
   name: xkeyboard-config
-  version: '2.42'
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.42-h4ab18f5_0.conda
-  sha256: 240caab7d9d85154ef373ecbac3ff9fb424add2029dbb124e949c6cbab2996dd
-  md5: b193af204da1bfb8c13882d131a14bd2
+  version: '2.43'
+  build: h86ecc28_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+  sha256: b3f09cc99b6b7707aa8812bbc7556fd431999ad3a48292e4ff82335b5fda976c
+  md5: a809b8e3776fbc05696c82f8cf6f5a92
   depends:
-  - libgcc-ng >=12
+  - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
-  size: 388998
-  timestamp: 1717817668629
+  size: 391011
+  timestamp: 1727840308426
 - kind: conda
   name: xkeyboard-config
-  version: '2.42'
-  build: h68df207_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.42-h68df207_0.conda
-  sha256: d89f3d4d513ab7512cd38dc1fcb5367cf1472a1a822df7a731b3e02270f91bd4
-  md5: 910ed255de2a0ec218a3c3db12d20a4d
+  version: '2.43'
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+  sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
+  md5: f725c7425d6d7c15e31f3b99a88ea02f
   depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
-  size: 388960
-  timestamp: 1717817664159
+  size: 389475
+  timestamp: 1727840188958
 - kind: conda
   name: xorg-glproto
   version: 1.4.17
@@ -23516,50 +26224,47 @@ packages:
   timestamp: 1641503532214
 - kind: conda
   name: xorg-libxdmcp
-  version: 1.1.3
-  build: h57736b2_2
-  build_number: 2
+  version: 1.1.5
+  build: h57736b2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h57736b2_2.conda
-  sha256: 2e53b95d23ffdfe7a0a5f6f2f93ee2d47366240b586ceef87224f19717c90588
-  md5: a914b757e423e28934e5881639325e18
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
+  md5: 25a5a7b797fe6e084e04ffe2db02fc62
   depends:
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 20581
-  timestamp: 1727620498307
+  size: 20615
+  timestamp: 1727796660574
 - kind: conda
   name: xorg-libxdmcp
-  version: 1.1.3
-  build: hb9d3cd8_2
-  build_number: 2
+  version: 1.1.5
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-hb9d3cd8_2.conda
-  sha256: c0d391f19dfe3b0fc6e66686a85a07061923e4a58bbc9db69cf2440169dbb24f
-  md5: 0f0d069428b003625074443455f25e0d
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 19954
-  timestamp: 1727619264777
+  size: 19901
+  timestamp: 1727794976192
 - kind: conda
   name: xorg-libxdmcp
-  version: 1.1.3
-  build: hd74edd7_2
-  build_number: 2
+  version: 1.1.5
+  build: hd74edd7_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-hd74edd7_2.conda
-  sha256: fe664b9aa7a759132b0deb951c11b6f71e4ebf64d3289be94d6f9e93ba46f65a
-  md5: 6aa30139d9b6f59e7c2f336d761df4f3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 18478
-  timestamp: 1727619299547
+  size: 18487
+  timestamp: 1727795205022
 - kind: conda
   name: xorg-libxext
   version: 1.3.6
@@ -23608,74 +26313,70 @@ packages:
   timestamp: 1727752280756
 - kind: conda
   name: xorg-libxfixes
-  version: 6.0.0
-  build: h57736b2_1
-  build_number: 1
+  version: 6.0.1
+  build: h57736b2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.0-h57736b2_1.conda
-  sha256: f3cba3482a7f91ebc88b4fb98a9e95afe9ba315f82ea7c2a38d2dc814e595262
-  md5: 8294832d503eaeaf5cc66513f3b8a5b4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
+  md5: 78f8715c002cc66991d7c11e3cf66039
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
-  size: 20366
-  timestamp: 1727619948701
+  size: 20289
+  timestamp: 1727796500830
 - kind: conda
   name: xorg-libxfixes
-  version: 6.0.0
-  build: hb9d3cd8_1
-  build_number: 1
+  version: 6.0.1
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.0-hb9d3cd8_1.conda
-  sha256: f94cb1198c6a50093db8bfad3b9b0a2c9f46e79e538a5d0ed5d09115fc873c7b
-  md5: bf964023af99d6cbbe51c1c00ca6b4c1
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+  sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
+  md5: 4bdb303603e9821baf5fe5fdff1dc8f8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
-  size: 19705
-  timestamp: 1727618702362
+  size: 19575
+  timestamp: 1727794961233
 - kind: conda
   name: xorg-libxi
-  version: 1.7.10
-  build: h57736b2_2
-  build_number: 2
+  version: 1.8.2
+  build: h57736b2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h57736b2_2.conda
-  sha256: 660188bf2d051b0cbb80009d66197712c330d949a7295665d7dcb1ba83bdd4e2
-  md5: 658e9fc84d0a39b6ceec76430373e99a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
+  md5: eeee3bdb31c6acde2b81ad1b8c287087
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes >=6.0.0,<7.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 47483
-  timestamp: 1727639525515
+  size: 48197
+  timestamp: 1727801059062
 - kind: conda
   name: xorg-libxi
-  version: 1.7.10
-  build: hb9d3cd8_2
-  build_number: 2
+  version: 1.8.2
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-hb9d3cd8_2.conda
-  sha256: 8499fc6278b1c0c98e209e3495bfc722bd2bccc55be9acaac581b65bf9e3fb21
-  md5: 22589726de8aa48df4543865011dc667
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes >=6.0.0,<7.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
-  size: 46832
-  timestamp: 1727638107602
+  size: 47179
+  timestamp: 1727799254088
 - kind: conda
   name: xorg-libxinerama
   version: 1.1.5
@@ -23768,99 +26469,103 @@ packages:
 - kind: conda
   name: xorg-libxpm
   version: 3.5.17
-  build: h31becfc_0
+  build: h86ecc28_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h31becfc_0.conda
-  sha256: f5cb60500bcbbeef572af4c0e861f8a87dcfb1eb96db248e4bb434563d1be47f
-  md5: 1058abf51071992b4be56884d13523cb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
+  sha256: ce7d4a2c075e594b034ee8080271dd7244b0e10a54f1aeb42a5d5eca2f3a950d
+  md5: b9fbc43bcc6bd9aa22f0aa4b81cac173
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   - xorg-libxt >=1.3.0,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 69622
-  timestamp: 1696449047382
+  size: 69584
+  timestamp: 1727801259630
 - kind: conda
   name: xorg-libxpm
   version: 3.5.17
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxpm-3.5.17-hb547adb_0.conda
-  sha256: 282e080e15c1b7a4625c6e041131b80001dae8658e2a0ae99dfa96868a0f9996
-  md5: 4f5ffcdcd4d0c48678f374c48109883e
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxt >=1.3.0,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
-  license: MIT
-  license_family: MIT
-  size: 56509
-  timestamp: 1696449340453
-- kind: conda
-  name: xorg-libxpm
-  version: 3.5.17
-  build: hd590300_0
+  build: hb9d3cd8_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hd590300_0.conda
-  sha256: f6b6cfe2b11bf5c50f7cc21a51a279f74d9f1135e91caba22e791ecc4f31fac0
-  md5: 12bf78e12f71405775e1c092902959d3
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
+  sha256: 8ce7ae21dcbbb759c6fb9e5ad2a2f2f4e54172adf160ea59e11712598edbb75c
+  md5: f35bec7fface97f67f44ca952fc740b7
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   - xorg-libxt >=1.3.0,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 64324
-  timestamp: 1696449073283
+  size: 64764
+  timestamp: 1727801210327
+- kind: conda
+  name: xorg-libxpm
+  version: 3.5.17
+  build: hd74edd7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxpm-3.5.17-hd74edd7_1.conda
+  sha256: ad5b72ef13b41ac89bb29282b3293478029df26bc596317899e8fd035f2c4df9
+  md5: e72da5101948cbab93fcafebcb91ee76
+  depends:
+  - __osx >=11.0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgettextpo >=0.22.5,<1.0a0
+  - libintl >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 54582
+  timestamp: 1727801268488
 - kind: conda
   name: xorg-libxrandr
-  version: 1.5.2
-  build: h86ecc28_2
-  build_number: 2
+  version: 1.5.4
+  build: h86ecc28_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.2-h86ecc28_2.conda
-  sha256: e7f9612a40f814874ce11896be45ca1fd97419c558914f541b8599f2a94808d3
-  md5: 03c47138711e586a8d51d8727096dd06
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
+  sha256: b2588a2b101d1b0a4e852532c8b9c92c59ef584fc762dd700567bdbf8cd00650
+  md5: dd3e74283a082381aa3860312e3c721e
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
   license: MIT
   license_family: MIT
-  size: 30321
-  timestamp: 1727618956547
+  size: 30197
+  timestamp: 1727794957221
 - kind: conda
   name: xorg-libxrandr
-  version: 1.5.2
-  build: hb9d3cd8_2
-  build_number: 2
+  version: 1.5.4
+  build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-hb9d3cd8_2.conda
-  sha256: 630ce67b2a4a175c526db3f18acc946f74f6d893d1051ce9c8b8e7d59856a3f3
-  md5: 7bc72b59601d8c94a5b49105aa631468
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+  sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
+  md5: 2de7f99d6581a4a7adbff607b5c278ca
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
   license: MIT
   license_family: MIT
-  size: 29855
-  timestamp: 1727618983747
+  size: 29599
+  timestamp: 1727794874300
 - kind: conda
   name: xorg-libxrender
   version: 0.9.11
@@ -24039,21 +26744,6 @@ packages:
   size: 30549
   timestamp: 1726846235301
 - kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: hd74edd7_1004
-  build_number: 1004
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-hd74edd7_1004.conda
-  sha256: 269c395b2a70ee744bfd2f2bfdcb009a0558711791a238a95e459eae5bba2838
-  md5: b353308d151470ab1a9e359502f3173b
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 30991
-  timestamp: 1726846405266
-- kind: conda
   name: xorg-xf86vidmodeproto
   version: 2.3.1
   build: h86ecc28_1003
@@ -24130,52 +26820,6 @@ packages:
   license_family: MIT
   size: 567698
   timestamp: 1726846426361
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: h57736b2_1008
-  build_number: 1008
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
-  sha256: 3415c89f81a03c26c0f2327c6d9b34a77de2e584d88a9157a5fd940f8cae0292
-  md5: 3dd2b75fd06be7955bd3b0c0afa4fb8f
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 73800
-  timestamp: 1726845752367
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: hb9d3cd8_1008
-  build_number: 1008
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-hb9d3cd8_1008.conda
-  sha256: ea02425c898d6694167952794e9a865e02e14e9c844efb067374f90b9ce8ce33
-  md5: a63f5b66876bb1ec734ab4bdc4d11e86
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 73315
-  timestamp: 1726845753874
-- kind: conda
-  name: xorg-xproto
-  version: 7.0.31
-  build: hd74edd7_1008
-  build_number: 1008
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-hd74edd7_1008.conda
-  sha256: cadde65a884af07d11433d5eefa986c9958c9319cd45cf7ab72c0809ce468332
-  md5: 7812af733bea6c9ecedfc45ab0f0135f
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 73637
-  timestamp: 1726845786323
 - kind: conda
   name: xz
   version: 5.2.6

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,12 @@ GZ_SIM_SYSTEM_PLUGIN_PATH = "$CONDA_PREFIX/lib"
 CMAKE_INSTALL_PREFIX = "%CONDA_PREFIX%\\Library"
 GZ_SIM_SYSTEM_PLUGIN_PATH = "%CONDA_PREFIX%\\Library\\bin"
 
+[feature.harmonic.activation.env]
+GSYP_BUILD_DIRECTORY_NAME = ".build_harmonic"
+
+[feature.ionic.activation.env]
+GSYP_BUILD_DIRECTORY_NAME = ".build_ionic"
+
 [tasks]
 
 configure = { cmd = [
@@ -30,19 +36,18 @@ configure = { cmd = [
     # The source is in the root directory
     "-S",
     ".",
-    # We wanna build in the .build directory
+    # We wanna build in the $GSYP_BUILD_DIRECTORY_NAME directory
     "-B",
-    ".build",
+    "$GSYP_BUILD_DIRECTORY_NAME"
 ]}
 
-build = { cmd = "cmake --build .build --config Release", depends_on = ["configure"] }
-test = { cmd = "ctest --test-dir .build --build-config Release --output-on-failure", depends_on = ["build"] }
-install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends_on = ["build"] }
-uninstall = { cmd = ["cmake", "--build", ".build", "--target", "uninstall"]}
+build = { cmd = "cmake --build $GSYP_BUILD_DIRECTORY_NAME --config Release", depends_on = ["configure"] }
+test = { cmd = "ctest --test-dir $GSYP_BUILD_DIRECTORY_NAME --build-config Release --output-on-failure", depends_on = ["build"] }
+install = { cmd = ["cmake", "--install", "$GSYP_BUILD_DIRECTORY_NAME", "--config", "Release"], depends_on = ["build"] }
+uninstall = { cmd = ["cmake", "--build", "$GSYP_BUILD_DIRECTORY_NAME", "--target", "uninstall"]}
 cpp-fmt = "fd --extension h --extension hh --extension hpp --extension c --extension cc --extension cpp --exec clang-format -i --verbose"
 
 [dependencies]
-libgz-sim8 = "*"
 yarp = "*"
 ycm-cmake-modules = "*"
 cmake = "*"
@@ -62,3 +67,13 @@ libegl-devel = "*"
 libgl-devel = "*"
 libopengl-devel = "*"
 libegl-devel = "*"
+
+[feature.harmonic.dependencies]
+libgz-sim8 = "*"
+
+[feature.ionic.dependencies]
+libgz-sim9 = "*"
+
+[environments]
+default = ["harmonic"]
+ionic = ["ionic"]


### PR DESCRIPTION
Fix https://github.com/robotology/gz-sim-yarp-plugins/issues/209 .

Requires https://github.com/robotology/gz-sim-yarp-plugins/pull/214 to be merged before (and eventually rebased).

The `default` pixi environment still uses Harmonic/gz-sim8, while the `ionic` environment used `Ionic/gz-sim9`. If both gz-sim8 and gz-sim9 are available in the system, at the moment CMake prefers gz-sim8, unless the users does not explicitly select the 9 by setting the `GZ_SIM_YARP_PLUGINS_USED_GZ_SIM_VERSION` to 9 during CMake configuration.