### PR TITLE
Fix compatibility with YARP 3.10

### DIFF
--- a/plugins/laser/LaserDriver.cpp
+++ b/plugins/laser/LaserDriver.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IRangefinder2D.h>
-#include <yarp/dev/LaserMeasurementData.h>
 #include <yarp/dev/Lidar2DDeviceBase.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>


### PR DESCRIPTION
Similar to https://github.com/robotology/gazebo-yarp-plugins/pull/690 . The `yarp/dev/LaserMeasurementData.h` is actually unused, and it changed location in YARP 3.10 : https://github.com/robotology/yarp/pull/3130, so we just remove it for compatibility with YARP 3.10 .