### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(gz-sim-yarp-plugins
         LANGUAGES CXX C
-        VERSION 0.3.0)
+        VERSION 0.3.1)
 
 find_package(YARP REQUIRED COMPONENTS robotinterface os)
 find_package(YCM REQUIRED)


### PR DESCRIPTION
This is required by the `LatestReleases` job of the superbuild in https://github.com/robotology/robotology-superbuild/pull/1747, as we need to build against YARP 3.10 and so we need to release https://github.com/robotology/gz-sim-yarp-plugins/pull/217 .