### PR TITLE
LaserTest: Replace deprecated and removed Rangefinder2DClient device with rangefinder2D_nwc_yarp device

### DIFF
--- a/tests/laser/LaserTest.cc
+++ b/tests/laser/LaserTest.cc
@@ -30,7 +30,7 @@ TEST(LaserTest, PluginTest)
     fixture.Server()->Run(/*_blocking=*/true, iterations, /*_paused=*/false);
 
     yarp::os::Property option;
-    option.put("device", "Rangefinder2DClient");
+    option.put("device", "rangefinder2D_nwc_yarp");
     option.put("remote", "/laser");
     option.put("local", "/LaserTest");
     yarp::dev::PolyDriver driver;


### PR DESCRIPTION
Fix https://github.com/robotology/gz-sim-yarp-plugins/issues/222 .

See https://github.com/robotology/yarp/releases/tag/v3.10.0 for the documentation on the removal of `Rangefinder2DClient` device.