### PR TITLE
Add missing override to getSixAxisForceTorqueSensorMeasure

### DIFF
--- a/plugins/forcetorque/ForceTorqueDriver.cpp
+++ b/plugins/forcetorque/ForceTorqueDriver.cpp
@@ -110,7 +110,7 @@ public:
     }
     virtual bool getSixAxisForceTorqueSensorMeasure(size_t sens_index,
                                                     yarp::sig::Vector& out,
-                                                    double& timestamp) const
+                                                    double& timestamp) const override
     {
         if (sens_index >= 1)
         {


### PR DESCRIPTION
This fixes the clang warning:

~~~
2024-12-07T13:50:41.3352070Z /Users/runner/work/gz-sim-yarp-plugins/gz-sim-yarp-plugins/plugins/forcetorque/ForceTorqueDriver.cpp:111:18: warning: 'getSixAxisForceTorqueSensorMeasure' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
2024-12-07T13:50:41.3451950Z   111 |     virtual bool getSixAxisForceTorqueSensorMeasure(size_t sens_index,
2024-12-07T13:50:41.3553160Z       |                  ^
2024-12-07T13:50:41.3655370Z /Users/runner/micromamba/envs/gzyarppluginsdev/include/yarp/dev/MultipleAnalogSensorsInterfaces.h:442:18: note: overridden virtual function is here
2024-12-07T13:50:41.3765080Z   442 |     virtual bool getSixAxisForceTorqueSensorMeasure(size_t sens_index, yarp::sig::Vector& out, double& timestamp) const = 0;
2024-12-07T13:50:41.3857210Z       |                  ^
2024-12-07T13:50:41.3958290Z 1 warning generated.
~~~