### PR TITLE
Change depends_on with depends-on in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -41,9 +41,9 @@ configure = { cmd = [
     "$GSYP_BUILD_DIRECTORY_NAME"
 ]}
 
-build = { cmd = "cmake --build $GSYP_BUILD_DIRECTORY_NAME --config Release", depends_on = ["configure"] }
-test = { cmd = "ctest --test-dir $GSYP_BUILD_DIRECTORY_NAME --build-config Release --output-on-failure", depends_on = ["build"] }
-install = { cmd = ["cmake", "--install", "$GSYP_BUILD_DIRECTORY_NAME", "--config", "Release"], depends_on = ["build"] }
+build = { cmd = "cmake --build $GSYP_BUILD_DIRECTORY_NAME --config Release", depends-on = ["configure"] }
+test = { cmd = "ctest --test-dir $GSYP_BUILD_DIRECTORY_NAME --build-config Release --output-on-failure", depends-on = ["build"] }
+install = { cmd = ["cmake", "--install", "$GSYP_BUILD_DIRECTORY_NAME", "--config", "Release"], depends-on = ["build"] }
 uninstall = { cmd = ["cmake", "--build", "$GSYP_BUILD_DIRECTORY_NAME", "--target", "uninstall"]}
 cpp-fmt = "fd --extension h --extension hh --extension hpp --extension c --extension cc --extension cpp --exec clang-format -i --verbose"
 


### PR DESCRIPTION
The `depends-on` syntax was supported since pixi 0.21 (see https://github.com/prefix-dev/pixi/pull/1310), so there risk of creating troubles to any user with an old pixi is non existent, as anyhow the lock file version that we used is newer if I am not wrong.