### PR TITLE
Remove all reset methods in Clock, ConfigurationOverride and ControlBoard plugins

### DIFF
--- a/plugins/clock/Clock.cc
+++ b/plugins/clock/Clock.cc
@@ -32,7 +32,7 @@ using yarp::os::BufferedPort;
 namespace gzyarp
 {
 
-class Clock : public System, public ISystemConfigure, public ISystemPostUpdate, public ISystemReset
+class Clock : public System, public ISystemConfigure, public ISystemPostUpdate
 {
 public:
     Clock()
@@ -114,11 +114,6 @@ public:
         m_clockPort.write();
     }
 
-    void Reset(const UpdateInfo& _info, EntityComponentManager& _ecm) override
-    {
-        yInfo() << "gz-sim-yarp-clock-system plugin Reset invoked.";
-    }
-
 private:
     bool m_initialized;
     // True if the YARP network needs to be reset to
@@ -135,5 +130,4 @@ private:
 GZ_ADD_PLUGIN(gzyarp::Clock,
               gz::sim::System,
               gzyarp::Clock::ISystemConfigure,
-              gzyarp::Clock::ISystemPostUpdate,
-              gzyarp::Clock::ISystemReset)
+              gzyarp::Clock::ISystemPostUpdate)

--- a/plugins/configurationoverride/ConfigurationOverride.cc
+++ b/plugins/configurationoverride/ConfigurationOverride.cc
@@ -32,7 +32,7 @@ using yarp::os::BufferedPort;
 namespace gzyarp
 {
 
-class ConfigurationOverride : public System, public ISystemConfigure, public ISystemPostUpdate, public ISystemReset
+class ConfigurationOverride : public System, public ISystemConfigure, public ISystemPostUpdate
 {
 public:
     ConfigurationOverride(): m_overrideInserted(false)
@@ -113,10 +113,6 @@ public:
     {
     }
 
-    void Reset(const UpdateInfo& _info, EntityComponentManager& _ecm) override
-    {
-    }
-
 private:
     bool m_overrideInserted;
     std::string m_configurationOverrideInstanceId;
@@ -128,5 +124,4 @@ private:
 GZ_ADD_PLUGIN(gzyarp::ConfigurationOverride,
               gz::sim::System,
               gzyarp::ConfigurationOverride::ISystemConfigure,
-              gzyarp::ConfigurationOverride::ISystemPostUpdate,
-              gzyarp::ConfigurationOverride::ISystemReset)
+              gzyarp::ConfigurationOverride::ISystemPostUpdate)

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -29,8 +29,7 @@ namespace gzyarp
 class ControlBoard : public gz::sim::System,
                      public gz::sim::ISystemConfigure,
                      public gz::sim::ISystemPreUpdate,
-                     public gz::sim::ISystemPostUpdate,
-                     public gz::sim::ISystemReset
+                     public gz::sim::ISystemPostUpdate
 {
 
 public:
@@ -50,9 +49,6 @@ public:
     // ISystemPostUpdate interface
     void PostUpdate(const gz::sim::UpdateInfo& _info,
                     const gz::sim::EntityComponentManager& _ecm) override;
-
-    // ISystemReset interface
-    void Reset(const gz::sim::UpdateInfo& _info, gz::sim::EntityComponentManager& _ecm) override;
 
 private:
     bool m_deviceRegistered;

--- a/plugins/controlboard/src/ControlBoard.cpp
+++ b/plugins/controlboard/src/ControlBoard.cpp
@@ -221,11 +221,6 @@ void ControlBoard::PostUpdate(const UpdateInfo& _info, const EntityComponentMana
     // checkForJointsHwFault();
 }
 
-void ControlBoard::Reset(const UpdateInfo& _info, EntityComponentManager& _ecm)
-{
-    resetPositionsAndTrajectoryGenerators(_ecm);
-}
-
 // Private methods
 
 bool ControlBoard::setJointProperties(EntityComponentManager& _ecm)
@@ -1112,5 +1107,4 @@ GZ_ADD_PLUGIN(gzyarp::ControlBoard,
               gz::sim::System,
               gzyarp::ControlBoard::ISystemConfigure,
               gzyarp::ControlBoard::ISystemPreUpdate,
-              gzyarp::ControlBoard::ISystemPostUpdate,
-              gzyarp::ControlBoard::ISystemReset)
+              gzyarp::ControlBoard::ISystemPostUpdate)


### PR DESCRIPTION
Defining the `ISystemReset` interface in some plugins and not in others create a problematic situation in which some plugins are restarted in a way (calling the destructor and constructor) and some other in another way (calling the reset method). This resulted in unexpected behaviour as the one reported in https://github.com/robotology/gz-sim-yarp-plugins/issues/206 .

To solve at least the crash, this PR removes all the reset methods. The downside of this is that now all the YARP ports are closed and re-opened at each reset, but anyhow this is better then just crash. 

Implementing a smarter reset strategy that does not restart the ports (that by the way is how Gazebo Classic and gazebo-yarp-plugins worked) will be tracked in https://github.com/robotology/gz-sim-yarp-plugins/issues/235 .