### PR TITLE
Permit to set enable_tags and disable_tags in gzyarp::RobotInterface robotinterface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(gz-sim-yarp-plugins
         LANGUAGES CXX C
-        VERSION 0.3.1)
+        VERSION 0.4.0)
 
 find_package(YARP REQUIRED COMPONENTS robotinterface os)
 find_package(YCM REQUIRED)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The plugins available in the repo are listed in the following.
 | `gzyarp::Imu` | `gz-sim-yarp-imu-system` | [Missing. If you need it please open an issue.](https://github.com/robotology/gz-sim-yarp-plugins/issues/new)  | [`tutorial/forcetorque`](./tutorial/imu) |
 | `gzyarp::Camera` | `gz-sim-yarp-camera-system` | [Missing. If you need it please open an issue.](https://github.com/robotology/gz-sim-yarp-plugins/issues/new)  | [`tutorial/camera`](./tutorial/imu) |
 | `gzyarp::BaseState` | `gz-sim-yarp-basestate-system` | [Missing. If you need it please open an issue.](https://github.com/robotology/gz-sim-yarp-plugins/issues/new)  | [`tutorial/basestate`](./tutorial/basestate) |
-| `gzyarp::RobotInterface` | `gz-sim-yarp-robotinterface-system` | [Missing. If you need it please open an issue.](https://github.com/robotology/gz-sim-yarp-plugins/issues/new)  | All tutorials in [`tutorial`](./tutorial) make use of the `gzyarp::RobotInterface` plugin. |
+| `gzyarp::RobotInterface` | `gz-sim-yarp-robotinterface-system` | [`robotinterface/README.md`](./robotinterface/README.md) | All tutorials in [`tutorial`](./tutorial) make use of the `gzyarp::RobotInterface` plugin. |
 | `gzyarp::Clock` | `gz-sim-yarp-clock-system` | [Missing. If you need it please open an issue.](https://github.com/robotology/gz-sim-yarp-plugins/issues/new)  | [`tutorial/clock`](./tutorial/clock) |
 
 You can see how to use the different plugins by looking in the directories contained in the [tutorial](tutorial/) folder of this repo. Each directory is an example, and contains a README that shows how to run that example.

--- a/libraries/common/ConfigurationHelpers.hh
+++ b/libraries/common/ConfigurationHelpers.hh
@@ -20,10 +20,10 @@ public:
     static bool loadRobotInterfaceConfiguration(const std::shared_ptr<const sdf::Element>& sdf,
                                                 yarp::robotinterface::XMLReaderResult& result);
 
+    static bool findFile(const std::string& filename, std::string& filepath);
+
 private:
     static bool isURI(const std::string& filepath);
-
-    static bool findFile(const std::string& filename, std::string& filepath);
 
     static bool
     loadYarpConfigurationFile(const std::string& yarpConfigurationFile, yarp::os::Property& config);

--- a/libraries/device-registry/DeviceRegistry.cc
+++ b/libraries/device-registry/DeviceRegistry.cc
@@ -65,9 +65,10 @@ bool DeviceRegistry::getDevicesAsPolyDriverList(const gz::sim::EntityComponentMa
         if (auto gzInstance_it = m_devicesMap.find(gzInstanceId);
             gzInstance_it == m_devicesMap.end())
         {
-            yError() << "Error in gzyarp::DeviceRegistry::getDevicesAsPolyDriverList: gz instance "
-                        "not found";
-            return false;
+            // If no instances is found, it probably means that getDevicesAsPolyDriverList is called
+            // for a gz instance that has not created any device yet, so just returning an empty list
+            // is the correct way to handle this case
+            return true;
         }
 
         auto& devicesMap = m_devicesMap.at(gzInstanceId);
@@ -353,24 +354,41 @@ bool DeviceRegistry::addConfigurationOverrideForYARPDevice(const gz::sim::Entity
                                            const std::string& configurationOverrideInstanceId,
                                            std::unordered_map<std::string, std::string> overridenParameters)
 {
-    m_yarpDevicesOverridenParametersList.push_back({getGzInstanceId(ecm),
+    m_yarpPluginsOverridenParametersList.push_back({getGzInstanceId(ecm),
                                                     parentEntityScopedNameWhereConfigurationOverrideWasInserted,
+                                                    OverrideType::YARP_DEVICE,
                                                     yarpDeviceName,
                                                     configurationOverrideInstanceId,
                                                     overridenParameters});
     return true;
 }
 
-bool DeviceRegistry::removeConfigurationOverrideForYARPDevice(const std::string& configurationOverrideInstanceId)
+bool DeviceRegistry::addConfigurationOverrideForYARPRobotInterface(const gz::sim::EntityComponentManager& ecm,
+    const std::string& parentEntityScopedNameWhereConfigurationOverrideWasInserted,
+    const std::string& yarpRobotInterfaceName,
+    const std::string& configurationOverrideInstanceId,
+    std::unordered_map<std::string, std::string> overridenParameters)
 {
-    m_yarpDevicesOverridenParametersList.erase(
+    m_yarpPluginsOverridenParametersList.push_back({getGzInstanceId(ecm),
+             parentEntityScopedNameWhereConfigurationOverrideWasInserted,
+             OverrideType::YARP_ROBOT_INTERFACE,
+             yarpRobotInterfaceName,
+             configurationOverrideInstanceId,
+             overridenParameters});
+    return true;
+}
+
+
+bool DeviceRegistry::removeConfigurationOverrideForYARPPlugin(const std::string& configurationOverrideInstanceId)
+{
+    m_yarpPluginsOverridenParametersList.erase(
         std::remove_if(
-            m_yarpDevicesOverridenParametersList.begin(),
-            m_yarpDevicesOverridenParametersList.end(),
+            m_yarpPluginsOverridenParametersList.begin(),
+            m_yarpPluginsOverridenParametersList.end(),
             [&configurationOverrideInstanceId](const ConfigurationOverrideParameters& params) {
                 return params.configurationOverrideInstanceId == configurationOverrideInstanceId;
             }),
-        m_yarpDevicesOverridenParametersList.end());
+            m_yarpPluginsOverridenParametersList.end());
     return true;
 }
 
@@ -387,10 +405,11 @@ bool DeviceRegistry::getConfigurationOverrideForYARPDevice(const gz::sim::Entity
     // is that the model scoped name of the place where the configuration override was inserted is a prefix of the
     // model scoped name of the device, to ensure that the override is applied only to the devices that are descendent
     // of the model where the configuration override was inserted
-    for (auto&& params : m_yarpDevicesOverridenParametersList) {
+    for (auto&& params : m_yarpPluginsOverridenParametersList) {
         if (params.gzInstanceId == getGzInstanceId(ecm) &&
             parentEntityScopedNameWhereYARPDeviceWasInserted.rfind(params.parentEntityScopedNameWhereConfigurationOverrideWasInserted) == 0 &&
-            params.yarpDeviceName == yarpDeviceName) {
+            params.overrideType == OverrideType::YARP_DEVICE &&
+            (params.yarpPluginIdentifier == yarpDeviceName || params.yarpPluginIdentifier == "all")) {
             std::unordered_map<std::string, std::string> consideredOverridenParameters = params.overridenParameters;
             overridenParameters.merge(consideredOverridenParameters);
         }
@@ -398,4 +417,32 @@ bool DeviceRegistry::getConfigurationOverrideForYARPDevice(const gz::sim::Entity
 
     return true;
 }
+
+bool DeviceRegistry::getConfigurationOverrideForYARPRobotInterface(const gz::sim::EntityComponentManager& ecm,
+    const std::string& parentEntityScopedNameWhereYARPRobotInterfaceWasInserted,
+    const std::string& yarpRobotInterfaceName,
+    std::unordered_map<std::string, std::string>& overridenParameters) const
+{
+    overridenParameters.clear();
+    // We go through all the overriden parameters and add to the returned overridenParameters all the matchin
+    // elements of the list. Note that earlier elements in the list have higher priority, to provide the possibility
+    // of overriding a parameter that was already overriden in a nested configuration override.
+    // Note that the condition for the overriden to be consider (beside matching gzInstanceId and yarpDeviceName)
+    // is that the model scoped name of the place where the configuration override was inserted is a prefix of the
+    // model scoped name of the device, to ensure that the override is applied only to the devices that are descendent
+    // of the model where the configuration override was inserted
+    for (auto&& params : m_yarpPluginsOverridenParametersList) {
+        if (params.gzInstanceId == getGzInstanceId(ecm) &&
+            parentEntityScopedNameWhereYARPRobotInterfaceWasInserted.rfind(params.parentEntityScopedNameWhereConfigurationOverrideWasInserted) == 0 &&
+            params.overrideType == OverrideType::YARP_ROBOT_INTERFACE &&
+            (params.yarpPluginIdentifier == yarpRobotInterfaceName || params.yarpPluginIdentifier == "all")) {
+            std::unordered_map<std::string, std::string> consideredOverridenParameters = params.overridenParameters;
+            overridenParameters.merge(consideredOverridenParameters);
+        }
+    }
+
+    return true;
+}
+
+
 } // namespace gzyarp

--- a/libraries/device-registry/DeviceRegistry.cc
+++ b/libraries/device-registry/DeviceRegistry.cc
@@ -424,7 +424,7 @@ bool DeviceRegistry::getConfigurationOverrideForYARPRobotInterface(const gz::sim
     std::unordered_map<std::string, std::string>& overridenParameters) const
 {
     overridenParameters.clear();
-    // We go through all the overriden parameters and add to the returned overridenParameters all the matchin
+    // We go through all the overriden parameters and add to the returned overridenParameters all the matching
     // elements of the list. Note that earlier elements in the list have higher priority, to provide the possibility
     // of overriding a parameter that was already overriden in a nested configuration override.
     // Note that the condition for the overriden to be consider (beside matching gzInstanceId and yarpDeviceName)

--- a/libraries/device-registry/DeviceRegistry.hh
+++ b/libraries/device-registry/DeviceRegistry.hh
@@ -110,7 +110,7 @@ public:
     void incrementNrOfGzSimYARPPluginsNotSuccessfullyLoaded(const gz::sim::EntityComponentManager& ecm);
 
     /**
-     * Add a configuration override for a given yarp device .
+     * Add a configuration override for a given yarp device.
      *
      * This function is meant to be called only by the gzyarp::ConfigurationOverride plugin.
      *
@@ -122,7 +122,7 @@ public:
                                                std::unordered_map<std::string, std::string> overridenParameters);
 
     /**
-     * Add a configuration override for a given yarp RobotInterface .
+     * Add a configuration override for a given yarp RobotInterface.
      *
      * This function is meant to be called only by the gzyarp::ConfigurationOverride plugin.
      *

--- a/libraries/device-registry/DeviceRegistry.hh
+++ b/libraries/device-registry/DeviceRegistry.hh
@@ -110,7 +110,7 @@ public:
     void incrementNrOfGzSimYARPPluginsNotSuccessfullyLoaded(const gz::sim::EntityComponentManager& ecm);
 
     /**
-     * Add a configuration override for a given yarp device.
+     * Add a configuration override for a given yarp device .
      *
      * This function is meant to be called only by the gzyarp::ConfigurationOverride plugin.
      *
@@ -122,10 +122,22 @@ public:
                                                std::unordered_map<std::string, std::string> overridenParameters);
 
     /**
-     * Remove a configuration override for a given yarp device.
+     * Add a configuration override for a given yarp RobotInterface .
+     *
+     * This function is meant to be called only by the gzyarp::ConfigurationOverride plugin.
      *
      */
-    bool removeConfigurationOverrideForYARPDevice(const std::string& configurationOverrideInstanceId);
+     bool addConfigurationOverrideForYARPRobotInterface(const gz::sim::EntityComponentManager& ecm,
+        const std::string& parentEntityScopedNameWhereConfigurationOverrideWasInserted,
+        const std::string& yarpRobotInterfaceName,
+        const std::string& configurationOverrideInstanceId,
+        std::unordered_map<std::string, std::string> overridenParameters);
+
+    /**
+     * Remove a configuration override for a gz-sim-yarp-plugin.
+     *
+     */
+    bool removeConfigurationOverrideForYARPPlugin(const std::string& configurationOverrideInstanceId);
 
     /**
      * Get the configuration override for a given yarp device.
@@ -137,6 +149,19 @@ public:
                                                const std::string& parentEntityScopedNameWhereYARPDeviceWasInserted,
                                                const std::string& yarpDeviceName,
                                                std::unordered_map<std::string, std::string>& overridenParameters) const;
+
+    /**
+     * Get the configuration override for a given yarpRobotInterfaceName.
+     *
+     * This function is meant to be called by the gz-yarp-robotinterface plugin to override its configuration.
+     *
+     * At the moment only the `all` yarpRobotInterfaceName special value (to represent all the robotinterface in the nested models) is supported.
+     */
+     bool getConfigurationOverrideForYARPRobotInterface(const gz::sim::EntityComponentManager& ecm,
+        const std::string& parentEntityScopedNameWhereYARPRobotInterfaceWasInserted,
+        const std::string& yarpRobotInterfaceName,
+        std::unordered_map<std::string, std::string>& overridenParameters) const;
+
 
     /**
      * Generate a unique device id for a given yarp device name and entity.
@@ -182,11 +207,15 @@ private:
     // Number of gz-sim-yarp-plugins YARP devices not loaded correctly for a given ecm
     std::unordered_map<std::string, std::size_t> m_nrOfGzSimYARPPluginsNotSuccessfullyLoaded;
 
+    enum OverrideType {
+        YARP_DEVICE,
+        YARP_ROBOT_INTERFACE
+    };
 
-    // Element that stores the parameters that will be overriden for a given yarp device
-    // A device will be affected by the override if:
+    // Element that stores the parameters that will be overriden for a given yarp device or robotinterface
+    // A plugin will be affected by the override if:
     // - gzInstanceId match
-    // - yarpDeviceName match
+    // - (overrideType,yarpPluginIdentifier) match
     // - the parentEntityScopedNameWhereConfigurationOverrideWasInserted is a prefix of the parent entity scoped name of the device`
     struct ConfigurationOverrideParameters {
         // Id that identifies the gz instance where the configuration override plugin was inserted
@@ -194,9 +223,11 @@ private:
         // Scoped name of the parent entity where the condiguration override plugin was inserted,
         // used to understand if a given yarp device is affected by the override
         std::string parentEntityScopedNameWhereConfigurationOverrideWasInserted;
-        // yarpDeviceName of the yarp device that will have its parameters overriden
-        std::string yarpDeviceName;
-        // configurationOverrideInstanceId is a unique id for each element in the m_yarpDevicesOverridenParametersList,
+        // Specify if this is a override for a device or a robotinterface
+        OverrideType overrideType;
+        // This is yarpDeviceName if overrideType==YARP_DEVICE or yarpRobotInterfaceName if overrideType==YARP_ROBOT_INTERFACE
+        std::string yarpPluginIdentifier;
+        // configurationOverrideInstanceId is a unique id for each element in the m_yarpPluginsOverridenParametersList,
         // it is used to remove a configuration override when the corresponding plugin is destroyed
         std::string configurationOverrideInstanceId;
         // Map of the parameters that will be overriden
@@ -206,8 +237,8 @@ private:
     };
 
     // This is a list of parameters specified by the configuration override plugin,
-    // they specify the parameters that will be overriden for a given yarp device
-    std::vector<ConfigurationOverrideParameters> m_yarpDevicesOverridenParametersList;
+    // they specify the parameters that will be overriden for a given yarp plugin (device or robotinterface)
+    std::vector<ConfigurationOverrideParameters> m_yarpPluginsOverridenParametersList;
 };
 
 } // namespace gzyarp

--- a/plugins/configurationoverride/ConfigurationOverride.cc
+++ b/plugins/configurationoverride/ConfigurationOverride.cc
@@ -46,7 +46,7 @@ public:
         // and will find the overrides specified by the destroyed gzyarp::ConfigurationOverride plugin
         if (m_overrideInserted)
         {
-            DeviceRegistry::getHandler()->removeConfigurationOverrideForYARPDevice(m_configurationOverrideInstanceId);
+            DeviceRegistry::getHandler()->removeConfigurationOverrideForYARPPlugin(m_configurationOverrideInstanceId);
             m_overrideInserted = false;
         }
     }
@@ -73,18 +73,23 @@ public:
             }
 
             sdf::ElementPtr yarpPluginConfigurationOverrideElem = sdfClone->GetElement("yarpPluginConfigurationOverride");
-            if (!yarpPluginConfigurationOverrideElem->HasAttribute("yarpDeviceName"))
+
+            // There are two possible way of specifying an override:
+            // * yarpDeviceName attribute, to specify that the override is related to a gz-sim-yarp-plugin that instantiates a YARP device
+            // * yarpRobotInterfaceName attribute, to specify that the override is related to a gz-sim-robotinterface-plugin (at the moment only the `all` special value is supported)
+            if (!yarpPluginConfigurationOverrideElem->HasAttribute("yarpDeviceName") && !yarpPluginConfigurationOverrideElem->HasAttribute("yarpRobotInterfaceName") )
             {
                 yError() << "Error in gzyarp::ConfigurationOverride::Configure: "
-                            "missing yarpDeviceName attribute of yarpPluginConfigurationOverride element";
+                            "missing yarpDeviceName or yarpRobotInterfaceName attribute of yarpPluginConfigurationOverride element";
                 return;
             }
 
-            std::string yarpDeviceName = yarpPluginConfigurationOverrideElem->GetAttribute("yarpDeviceName")->GetAsString();
-
-            if (sdfClone->HasElement("initialConfiguration"))
+            // Only one of yarpDeviceName or yarpRobotInterfaceName can be specified
+            if (yarpPluginConfigurationOverrideElem->HasAttribute("yarpDeviceName") && yarpPluginConfigurationOverrideElem->HasAttribute("yarpRobotInterfaceName"))
             {
-                overridenParameters["gzyarp-xml-element-initialConfiguration"] = sdfClone->Get<std::string>("initialConfiguration");
+                yError() << "Error in gzyarp::ConfigurationOverride::Configure: "
+                            "both yarpDeviceName and yarpRobotInterfaceName attributes of yarpPluginConfigurationOverride element are specified, while only one of the two is supported";
+                return;
             }
 
             // Define unique key to identify the configuration override and then remove it
@@ -92,17 +97,63 @@ public:
             ss << this;
             m_configurationOverrideInstanceId = DeviceRegistry::getGzInstanceId(_ecm) + "_" + ss.str();
 
-            if (!DeviceRegistry::getHandler()->addConfigurationOverrideForYARPDevice(
-                    _ecm,
-                    scopedName(_entity, _ecm, "/"),
-                    yarpDeviceName,
-                    m_configurationOverrideInstanceId,
-                    overridenParameters))
+            // This code is used if yarpDeviceName is specified
+            if (yarpPluginConfigurationOverrideElem->HasAttribute("yarpDeviceName"))
             {
-                yError() << "Error in gzyarp::ConfigurationOverride::Configure: "
-                            "addConfigurationOverrideForYARPDevice failed";
-                return;
+                std::string yarpDeviceName = yarpPluginConfigurationOverrideElem->GetAttribute("yarpDeviceName")->GetAsString();
+
+                if (sdfClone->HasElement("initialConfiguration"))
+                {
+                    overridenParameters["gzyarp-xml-element-initialConfiguration"] = sdfClone->Get<std::string>("initialConfiguration");
+                }
+
+                if (!DeviceRegistry::getHandler()->addConfigurationOverrideForYARPDevice(
+                        _ecm,
+                        scopedName(_entity, _ecm, "/"),
+                        yarpDeviceName,
+                        m_configurationOverrideInstanceId,
+                        overridenParameters))
+                {
+                    yError() << "Error in gzyarp::ConfigurationOverride::Configure: "
+                                "addConfigurationOverrideForYARPDevice failed";
+                    return;
+                }
             }
+
+            // This code is used if yarpRobotInterfaceName is specified
+            {
+                std::string yarpRobotInterfaceName = yarpPluginConfigurationOverrideElem->GetAttribute("yarpRobotInterfaceName")->GetAsString();
+
+                if (yarpRobotInterfaceName != "all")
+                {
+                    yError() << "Error in gzyarp::ConfigurationOverride::Configure: "
+                                "yarpRobotInterfaceName attribute of yarpPluginConfigurationOverride element must be 'all'";
+                    return;
+                }
+
+                if (sdfClone->HasElement("yarpRobotInterfaceEnableTags"))
+                {
+                    overridenParameters["gzyarp-xml-element-yarpRobotInterfaceEnableTags"] = sdfClone->Get<std::string>("yarpRobotInterfaceEnableTags");
+                }
+
+                if (sdfClone->HasElement("yarpRobotInterfaceDisableTags"))
+                {
+                    overridenParameters["gzyarp-xml-element-yarpRobotInterfaceDisableTags"] = sdfClone->Get<std::string>("yarpRobotInterfaceDisableTags");
+                }
+
+                if (!DeviceRegistry::getHandler()->addConfigurationOverrideForYARPRobotInterface(
+                        _ecm,
+                        scopedName(_entity, _ecm, "/"),
+                        yarpRobotInterfaceName,
+                        m_configurationOverrideInstanceId,
+                        overridenParameters))
+                {
+                    yError() << "Error in gzyarp::ConfigurationOverride::Configure: "
+                                "addConfigurationOverrideForYARPRobotInterface failed";
+                    return;
+                }
+            }
+
 
             m_overrideInserted = true;
             configureHelper.setConfigureIsSuccessful(true);

--- a/plugins/configurationoverride/ConfigurationOverride.cc
+++ b/plugins/configurationoverride/ConfigurationOverride.cc
@@ -121,6 +121,7 @@ public:
             }
 
             // This code is used if yarpRobotInterfaceName is specified
+            if (yarpPluginConfigurationOverrideElem->HasAttribute("yarpRobotInterfaceName"))
             {
                 std::string yarpRobotInterfaceName = yarpPluginConfigurationOverrideElem->GetAttribute("yarpRobotInterfaceName")->GetAsString();
 

--- a/plugins/configurationoverride/README.md
+++ b/plugins/configurationoverride/README.md
@@ -48,7 +48,7 @@ Another tipical example of `gzyarp::ConfigurationOverride` plugin is to set the 
 |:------------:|:-----------------------:|
 | `yarpPluginConfigurationOverride` | The attributes of this element specify the plugin of which we will override the parameters. Possible attributes are `yarpDeviceName`, that specifies the `yarpDeviceName='@yarpDeviceName@'` instantiated by the plugin to override, or `yarpRobotInterfaceName='@yarpRobotInterfaceName@'` to override the parameters of  `gzyarp::RobotInterface` plugins named `yarpRobotInterfaceName`. In both cases, you can pass `all` to override the parameters of all YARP devices or YARP RobotInterface plugins in all nested models. |
 
-The parameters and plugins currently supported by the `gzyarp::ConfigurationOverride` plugin, that need to:
+The parameters and plugins currently supported by the `gzyarp::ConfigurationOverride` plugin are the following:
 
 | Parameter SDF Element name       | Overrided Plugin |
 |:--------------------------------:|:---------------------:|

--- a/plugins/configurationoverride/README.md
+++ b/plugins/configurationoverride/README.md
@@ -10,13 +10,6 @@ and that occurs in `xml` after the insertion of the ConfigurationOverride plugin
 
 Each ConfigurationOverride plugin points to another plugin using a unique identifier, and can override the values of its configuration parameters.
 
-The parameters and plugins currently supported by the `gzyarp::ConfigurationOverride` plugin are:
-
-| Parameter SDF Element name     | Overrided Plugin |
-|:------------------------------:|:---------------------:|
-| `initialConfiguration`         | `gzyarp::ControlBoard` |
-
-Any other parameter is not overriden. The plan for the future is to support more parameters in the `gzyarp::ConfigurationOverride`, if there is some specific parameter that you would like to override via the `gzyarp::ConfigurationOverride`, please [open an issue](https://github.com/robotology/gz-sim-yarp-plugins/issues/new).
 
 ### Usage
 
@@ -41,8 +34,27 @@ The relevant snippet is:
     </plugin>
 ```
 
-The original `initialConfiguration` of the `controlboard_plugin_device` was `0.0`, while via the `gzyarp::ConfigurationOverride` plugin we override its value to be `0.785398` rad (i.e. 45 degrees).]
+The original `initialConfiguration` of the `controlboard_plugin_device` was `0.0`, while via the `gzyarp::ConfigurationOverride` plugin we override its value to be `0.785398` rad (i.e. 45 degrees).
 
 Note that the `<plugin name='gzyarp::ConfigurationOverride' [...]>` element is child of another parent `<model>`.
 
 This is required as Gazebo Harmonic (`gz-sim8`) there are some inconsistency related to the scoped name of the entity passed to plugin inserted under the `world` element. If you are using Gazebo Ionic (`gz-sim9`) or later, you can also insert directly the  `<plugin name='gzyarp::ConfigurationOverride' [...]>` as a child of the `<world>` element.
+
+Another tipical example of `gzyarp::ConfigurationOverride` plugin is to set the enable and disable tags of a `gzyarp::RobotInteface` plugin, you can read more about that in [`gzyarp::RobotInterface` documentation](../robotinterface/README.md).
+
+### Reference documentation of `plugin` child XML elements
+
+| XML element | Documentation |
+|:------------:|:-----------------------:|
+| `yarpPluginConfigurationOverride` | The attributes of this element specify the plugin of which we will override the parameters. Possible attributes are `yarpDeviceName`, that specifies the `yarpDeviceName='@yarpDeviceName@'` instantiated by the plugin to override, or `yarpRobotInterfaceName='@yarpRobotInterfaceName@'` to override the parameters of  `gzyarp::RobotInterface` plugins named `yarpRobotInterfaceName`. In both cases, you can pass `all` to override the parameters of all YARP devices or YARP RobotInterface plugins in all nested models. |
+
+The parameters and plugins currently supported by the `gzyarp::ConfigurationOverride` plugin, that need to:
+
+| Parameter SDF Element name       | Overrided Plugin |
+|:--------------------------------:|:---------------------:|
+| `initialConfiguration`           | `gzyarp::ControlBoard` |
+| `yarpRobotInterfaceEnableTags`   | `gzyarp::RobotInterface` |
+| `yarpRobotInterfaceDisableTags`  | `gzyarp::RobotInterface` |
+
+
+Any other parameter is not overriden. The plan for the future is to support more parameters in the `gzyarp::ConfigurationOverride`, if there is some specific parameter that you would like to override via the `gzyarp::ConfigurationOverride`, please [open an issue](https://github.com/robotology/gz-sim-yarp-plugins/issues/new).

--- a/plugins/controlboard/src/ControlBoard.cpp
+++ b/plugins/controlboard/src/ControlBoard.cpp
@@ -107,9 +107,6 @@ void ControlBoard::Configure(const Entity& _entity,
     std::string yarpDeviceName = m_pluginParameters.find("yarpDeviceName").asString();
 
     m_robotScopedName = gz::sim::scopedName(_entity, _ecm, "/");
-    yDebug() << "gz-sim-yarp-controlboard-system : robot scoped name: " << m_robotScopedName;
-    yDebug() << "gz-sim-yarp-controlboard-system : yarpDeviceName: " << yarpDeviceName;
-
     m_modelEntity = _entity;
 
     m_pluginParameters.put(yarp::dev::gzyarp::YarpControlBoardScopedName.c_str(),

--- a/plugins/robotinterface/README.md
+++ b/plugins/robotinterface/README.md
@@ -7,7 +7,7 @@
 
 The `gzyarp::RobotInterface` plugin is used to instantiate arbitrary YARP devices as part of a `gz-sim` simulation, using the [YARP RobotInterface library](https://www.yarp.it/latest/group__robointerface__all.html).
 
-Particularly, tipically the YARP devices that simulate hardware devices are instantiated via dedicated `gz-sim-yarp-*` `gz-sim` plugins, while to launch any other YARP device, for example [Network Wrapper Servers](https://yarp.it/latest/group__nws__and__nwc__architecture.html) to expose YARP devices functionalities in dedicated middlewares like YARP ports or ROS2 topics.
+Particularly, tipically the YARP devices that simulate hardware devices are instantiated via dedicated `gz-sim-yarp-*` `gz-sim` plugins, while to launch any other YARP device, for example [Network Wrapper Servers](https://yarp.it/latest/group__nws__and__nwc__architecture.html) to expose YARP devices functionalities in dedicated middlewares like YARP ports or ROS2 topics, you need to use the `gzyarp::RobotInterface` plugin.
 
 ### Usage
 

--- a/plugins/robotinterface/README.md
+++ b/plugins/robotinterface/README.md
@@ -1,0 +1,67 @@
+### gzyarp::RobotInterface Plugin
+
+
+| `name`        | `filename`         |
+|:-------------:|:------------------:|
+| `gzyarp::RobotInterface` |  `gz-sim-yarp-robotinterface-system` |
+
+The `gzyarp::RobotInterface` plugin is used to instantiate arbitrary YARP devices as part of a `gz-sim` simulation, using the [YARP RobotInterface library](https://www.yarp.it/latest/group__robointerface__all.html).
+
+Particularly, tipically the YARP devices that simulate hardware devices are instantiated via dedicated `gz-sim-yarp-*` `gz-sim` plugins, while to launch any other YARP device, for example [Network Wrapper Servers](https://yarp.it/latest/group__nws__and__nwc__architecture.html) to expose YARP devices functionalities in dedicated middlewares like YARP ports or ROS2 topics.
+
+### Usage
+
+Add the `gzyarp::RobotInterface` plugin to the model SDF after all the plugin declarations that instantiated YARP devices that you want to use.
+
+An example of its usage can be seen in the [`tutorial/single_pendulum/single_pendulum_world.sdf`](../../tutorial/single_pendulum/model.sdf)
+
+A more complete example of the usage is:
+
+```xml
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+            <yarpConfigurationFile>
+                model://single_pendulum/conf/gazebo_controlboard.ini
+            </yarpConfigurationFile>
+        </plugin>
+        <!-- Launch the other YARP devices, in this case a controlBoard_nws_yarp to expose the
+        controlboard functionalities via YARP ports -->
+        <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
+            <yarpRobotInterfaceConfigurationFile>
+                model://single_pendulum/conf/single_pendulum_nws.xml
+            </yarpRobotInterfaceConfigurationFile>
+            <!-- This element can be used to pass "enable" tags to the libYARP_robotinterface instance -->
+            <yarpRobotInterfaceEnableTags>
+            (enable_tag1 enable_tag2)
+            </yarpRobotInterfaceEnableTags>
+            <!-- This element can be used to pass "disable" tags to the libYARP_robotinterface instance -->
+            <yarpRobotInterfaceDisableTags>
+            (disable_tagA)
+            </yarpRobotInterfaceDisableTags>
+        </plugin>
+```
+
+The `yarpRobotInterfaceEnableTags` and `yarpRobotInterfaceDisableTags` can also be overriden via the `gzyarp::ConfigurationOverride` plugin,
+for example if `model://model_with_robotinterface_inside` is a gz-sim model with a `gzyarp::RobotInterface` plugin inside, you can specify the `enable_tags` or `disable_tags` to specify with:
+
+```xml
+    <model name="robotinterface_with_overriden_tags">
+        <plugin name='gzyarp::ConfigurationOverride' filename='gz-sim-yarp-configurationoverride-system'>
+            <!-- The yarpPluginConfigurationOverride device is used to override the configuration of
+                 a given gzyarp::RobotInterface plugin, whose name (the one specified inside the xml file) is specified with yarpRobotInterfaceName, or you can specify `all` to ensure that the enable tags will be specified for all -->
+            <yarpPluginConfigurationOverride yarpRobotInterfaceName='all'/>
+            <yarpRobotInterfaceEnableTags>(enable_tag1)</yarpRobotInterfaceEnableTags>
+            <yarpRobotInterfaceDisableTags>(disable_tagA disable_tagB)</yarpRobotInterfaceDisableTags>
+        </plugin>
+        <include>
+            <uri>model://model_with_robotinterface_inside</uri>
+        </include>
+    </model>
+```
+
+### Reference documentation of `plugin` child XML elements
+
+| XML element | Documentation |
+|:------------:|:-----------------------:|
+| `yarpRobotInterfaceConfigurationFile` | The [YARP robotinterface XML file](https://www.yarp.it/latest/group__yarp__robotinterface__xml__config__files.html) that specifies the YARP devices that will be launched by the `gzyarp::RobotInterface` plugin. |
+| `yarpRobotInterfaceEnableTags` | This element can be used to pass "enable" tags to the libYARP_robotinterface instance. |
+| `yarpRobotInterfaceDisableTags` | This element can be used to pass "disable" tags to the libYARP_robotinterface instance. |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_subdirectory(camera)
 add_subdirectory(controlboard)
 add_subdirectory(commons)
 add_subdirectory(test-helpers)
+add_subdirectory(robotinterface)
+
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(Fetchtiny-process-library)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,6 @@ add_subdirectory(commons)
 add_subdirectory(test-helpers)
 add_subdirectory(robotinterface)
 
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(Fetchtiny-process-library)
 add_subdirectory(clock)

--- a/tests/robotinterface/CMakeLists.txt
+++ b/tests/robotinterface/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(RobotInterfaceTest RobotInterfaceTest.cc)
+target_link_libraries(RobotInterfaceTest
+  GTest::gtest_main
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+  gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+  YARP::YARP_dev
+)
+add_test(NAME RobotInterfaceTest
+         COMMAND RobotInterfaceTest)
+
+set_tests_properties(RobotInterfaceTest PROPERTIES
+  ENVIRONMENT_MODIFICATION "GZ_SIM_SYSTEM_PLUGIN_PATH=path_list_append:$<TARGET_FILE_DIR:gz-sim-yarp-robotinterface-system>"
+  ENVIRONMENT_MODIFICATION "GZ_SIM_RESOURCE_PATH=path_list_append:${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_definitions(RobotInterfaceTest
+  PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)

--- a/tests/robotinterface/CMakeLists.txt
+++ b/tests/robotinterface/CMakeLists.txt
@@ -9,8 +9,7 @@ add_test(NAME RobotInterfaceTest
          COMMAND RobotInterfaceTest)
 
 set_tests_properties(RobotInterfaceTest PROPERTIES
-  ENVIRONMENT_MODIFICATION "GZ_SIM_SYSTEM_PLUGIN_PATH=path_list_append:$<TARGET_FILE_DIR:gz-sim-yarp-robotinterface-system>"
-  ENVIRONMENT_MODIFICATION "GZ_SIM_RESOURCE_PATH=path_list_append:${CMAKE_CURRENT_SOURCE_DIR}")
+  ENVIRONMENT_MODIFICATION "GZ_SIM_SYSTEM_PLUGIN_PATH=path_list_append:$<TARGET_FILE_DIR:gz-sim-yarp-robotinterface-system>;GZ_SIM_RESOURCE_PATH=path_list_append:${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_compile_definitions(RobotInterfaceTest
   PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"

--- a/tests/robotinterface/RobotInterfaceTest.cc
+++ b/tests/robotinterface/RobotInterfaceTest.cc
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <gz/common/Console.hh>
+#include <gz/sim/TestFixture.hh>
+
+#include <yarp/conf/environment.h>
+#include <yarp/dev/Drivers.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Log.h>
+#include <yarp/os/Network.h>
+
+// This global flags are set by devices to easily check which devices were loaded
+std::atomic<bool> g_device1WasLoaded = false;
+std::atomic<bool> g_device2WasLoaded = false;
+
+void resetLoadedFlags()
+{
+    g_device1WasLoaded = false;
+    g_device2WasLoaded = false;
+}
+
+class gsypRobotInterfaceTestDevice1 : public yarp::dev::DeviceDriver
+{
+public:
+    gsypRobotInterfaceTestDevice1() = default;
+    ~gsypRobotInterfaceTestDevice1() override = default;
+
+    bool open(yarp::os::Searchable&) override
+    {
+        g_device1WasLoaded = true;
+        return true;
+    }
+
+    bool close() override
+    {
+        return true;
+    }
+};
+
+class gsypRobotInterfaceTestDevice2 : public yarp::dev::DeviceDriver
+{
+public:
+    gsypRobotInterfaceTestDevice2() = default;
+    ~gsypRobotInterfaceTestDevice2() override = default;
+
+    bool open(yarp::os::Searchable&) override
+    {
+        g_device2WasLoaded = true;
+        return true;
+    }
+
+    bool close() override
+    {
+        return true;
+    }
+};
+
+
+
+TEST(RobotInterfaceTest, CheckEnableAndDisableTags)
+{
+    yarp::os::NetworkBase::setLocalMode(true);
+
+    // Add devices used for tests
+    ::yarp::dev::Drivers::factory().add(
+        new ::yarp::dev::DriverCreatorOf<gsypRobotInterfaceTestDevice1>("gsypRobotInterfaceTestDevice1",
+                                                                         "",
+                                                                         ""));
+    ::yarp::dev::Drivers::factory().add(
+        new ::yarp::dev::DriverCreatorOf<gsypRobotInterfaceTestDevice2>("gsypRobotInterfaceTestDevice2",
+                                                                         "",
+                                                                         ""));
+
+    resetLoadedFlags();
+    auto modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "robotinterface_with_default_tags.sdf";
+    std::cerr << "Testing world " << modelPath << std::endl;
+    gz::sim::TestFixture fixtureDefault(modelPath.string());
+    fixtureDefault.Finalize();
+    EXPECT_FALSE(g_device1WasLoaded);
+    EXPECT_FALSE(g_device2WasLoaded);
+
+    resetLoadedFlags();
+    modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "robotinterface_with_enable_device1.sdf";
+    std::cerr << "Testing world " << modelPath << std::endl;
+    gz::sim::TestFixture fixtureEnableDevice1(modelPath.string());
+    fixtureEnableDevice1.Finalize();
+    EXPECT_TRUE(g_device1WasLoaded);
+    EXPECT_FALSE(g_device2WasLoaded);
+
+    resetLoadedFlags();
+    modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "robotinterface_with_enable_device1_and_device2.sdf";
+    std::cerr << "Testing world " << modelPath << std::endl;
+    gz::sim::TestFixture fixtureEnableDevice1andDevice2(modelPath.string());
+    fixtureEnableDevice1andDevice2.Finalize();
+    EXPECT_TRUE(g_device1WasLoaded);
+    EXPECT_TRUE(g_device2WasLoaded);
+
+    resetLoadedFlags();
+    modelPath = std::filesystem::path(CMAKE_CURRENT_SOURCE_DIR) / "robotinterface_with_enable_device1_and_device2_disable_device1.sdf";
+    std::cerr << "Testing world " << modelPath << std::endl;
+    gz::sim::TestFixture fixtureEnableDevice1andDevice2DisableDevice1(modelPath.string());
+    fixtureEnableDevice1andDevice2DisableDevice1.Finalize();
+    EXPECT_FALSE(g_device1WasLoaded);
+    EXPECT_TRUE(g_device2WasLoaded);
+}
+

--- a/tests/robotinterface/robotinterface_config.xml
+++ b/tests/robotinterface/robotinterface_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="robotinterface_test" portprefix="/robotinterface_test" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <xi:include href="./robotinterface_config_device1.xml" enabled_by="enable_device1" disabled_by="disable_device1" />
+        <xi:include href="./robotinterface_config_device2.xml" enabled_by="enable_device2" disabled_by="disable_device2" />
+    </devices>
+</robot>

--- a/tests/robotinterface/robotinterface_config_device1.xml
+++ b/tests/robotinterface/robotinterface_config_device1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="robotinterface_test_device1" type="gsypRobotInterfaceTestDevice1" />

--- a/tests/robotinterface/robotinterface_config_device2.xml
+++ b/tests/robotinterface/robotinterface_config_device2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="robotinterface_test_device2" type="gsypRobotInterfaceTestDevice2" />

--- a/tests/robotinterface/robotinterface_with_default_tags.sdf
+++ b/tests/robotinterface/robotinterface_with_default_tags.sdf
@@ -1,0 +1,28 @@
+
+<?xml version="1.0"?>
+
+<sdf version="1.11">
+    <model name="robotinterface_with_default_tags">
+        <joint name="fixed_base" type="fixed">
+            <parent>world</parent>
+            <child>base_link</child>
+        </joint>
+        <link name='base_link'>
+            <inertial>
+                <pose>0 0 0 0 0 0</pose>
+                <mass>100</mass>
+                <inertia>
+                    <ixx>1</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>1</iyy>
+                    <iyz>0</iyz>
+                    <izz>1</izz>
+                </inertia>
+            </inertial>
+        </link>
+        <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
+            <yarpRobotInterfaceConfigurationFile>model://robotinterface_config.xml</yarpRobotInterfaceConfigurationFile>
+        </plugin>
+    </model>
+</sdf>

--- a/tests/robotinterface/robotinterface_with_enable_device1.sdf
+++ b/tests/robotinterface/robotinterface_with_enable_device1.sdf
@@ -1,0 +1,16 @@
+
+<?xml version="1.0"?>
+
+<sdf version="1.11">
+    <world name="world_with_robotinterface_with_overriden_tags">
+        <model name="robotinterface_with_overriden_tags">
+            <plugin name='gzyarp::ConfigurationOverride' filename='gz-sim-yarp-configurationoverride-system'>
+                <yarpPluginConfigurationOverride yarpRobotInterfaceName='all'/>
+                <yarpRobotInterfaceEnableTags>(enable_device1)</yarpRobotInterfaceEnableTags>
+            </plugin>
+            <include>
+                <uri>model://robotinterface_with_default_tags.sdf</uri>
+            </include>
+        </model>
+    </world>
+</sdf>

--- a/tests/robotinterface/robotinterface_with_enable_device1_and_device2.sdf
+++ b/tests/robotinterface/robotinterface_with_enable_device1_and_device2.sdf
@@ -1,0 +1,16 @@
+
+<?xml version="1.0"?>
+
+<sdf version="1.11">
+    <world name="world_with_robotinterface_with_overriden_tags">
+        <model name="robotinterface_with_overriden_tags">
+            <plugin name='gzyarp::ConfigurationOverride' filename='gz-sim-yarp-configurationoverride-system'>
+                <yarpPluginConfigurationOverride yarpRobotInterfaceName='all'/>
+                <yarpRobotInterfaceEnableTags>(enable_device1 enable_device2)</yarpRobotInterfaceEnableTags>
+            </plugin>
+            <include>
+                <uri>model://robotinterface_with_default_tags.sdf</uri>
+            </include>
+        </model>
+    </world>
+</sdf>

--- a/tests/robotinterface/robotinterface_with_enable_device1_and_device2_disable_device1.sdf
+++ b/tests/robotinterface/robotinterface_with_enable_device1_and_device2_disable_device1.sdf
@@ -1,0 +1,17 @@
+
+<?xml version="1.0"?>
+
+<sdf version="1.11">
+    <world name="world_with_robotinterface_with_overriden_tags">
+        <model name="robotinterface_with_overriden_tags">
+            <plugin name='gzyarp::ConfigurationOverride' filename='gz-sim-yarp-configurationoverride-system'>
+                <yarpPluginConfigurationOverride yarpRobotInterfaceName='all'/>
+                <yarpRobotInterfaceEnableTags>(enable_device1 enable_device2)</yarpRobotInterfaceEnableTags>
+                <yarpRobotInterfaceDisableTags>(disable_device1)</yarpRobotInterfaceDisableTags>
+            </plugin>
+            <include>
+                <uri>model://robotinterface_with_default_tags.sdf</uri>
+            </include>
+        </model>
+    </world>
+</sdf>


### PR DESCRIPTION
Fix https://github.com/robotology/gz-sim-yarp-plugins/issues/163 .

This PR does the following (sorry for the relative big PR):
* Add documentation for the `gzyarp::RobotInterface` (as otherwise it was impossible to document the new functionalities if we did not document the basic functionalities of the plugin)
* Add the support in `gzyarp::RobotInterface` to specify `enable_tags` and `disable_tags` (as described in YARP documentation, see https://www.yarp.it/latest/group__yarp__robotinterface__xml__config__files.html) via the `yarpRobotInterfaceEnableTags` and `yarpRobotInterfaceDisableTags` elements.
* Add support for overloading  `yarpRobotInterfaceEnableTags` and `yarpRobotInterfaceDisableTags` elements via the `gzyarp::ConfigurationOverride` plugin added in https://github.com/robotology/gz-sim-yarp-plugins/pull/232 .

All these functionalities permit to write models in which some YARP devices created by the yarprobotinterface can be enabled and disabled, also from the world that includes the model.

A simple example of this functionality is:

~~~xml
    <model name="robotinterface_with_overriden_tags">
        <plugin name='gzyarp::ConfigurationOverride' filename='gz-sim-yarp-configurationoverride-system'>
            <!-- The yarpPluginConfigurationOverride device is used to override the configuration of
                 a given gzyarp::RobotInterface plugin, whose name (the one specified inside the xml file) is specified with yarpRobotInterfaceName, or you can specify `all` to ensure that the enable tags will be specified for all -->
            <yarpPluginConfigurationOverride yarpRobotInterfaceName='all'/>
            <yarpRobotInterfaceEnableTags>(enable_tag1)</yarpRobotInterfaceEnableTags>
            <yarpRobotInterfaceDisableTags>(disable_tagA disable_tagB)</yarpRobotInterfaceDisableTags>
        </plugin>
        <include>
            <uri>model://model_with_robotinterface_inside</uri>
        </include>
    </model>
~~~

(from the `gzyarp::RobotInterface` docs).

The implemented functionality has been validated with a dedicated `RobotInterfaceTest`.