### PR TITLE
Fix compilation with YARP master branch (future YARP 3.12) as of 2025/02/25

### DIFF
--- a/libraries/common/CMakeLists.txt
+++ b/libraries/common/CMakeLists.txt
@@ -1,3 +1,5 @@
+# This library is installed as it is a shared library, but no headers are installed,
+# so the headers are effectively private headers, even if the library they belong to is installed
 add_library(gz-sim-yarp-commons SHARED Common.hh ConfigurationHelpers.hh ConfigurationHelpers.cpp)
 
 target_include_directories(gz-sim-yarp-commons PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")

--- a/libraries/common/Common.hh
+++ b/libraries/common/Common.hh
@@ -6,6 +6,8 @@
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Value.h>
 
+#include "YarpDevReturnValueCompat.h"
+
 namespace gzyarp
 {
 constexpr double pi = 3.1415926535897932384626433;
@@ -108,3 +110,5 @@ inline bool readVectorFromConfigFile(const yarp::os::Searchable& params,
 }
 
 } // namespace gzyarp
+
+

--- a/libraries/common/YarpDevReturnValueCompat.h
+++ b/libraries/common/YarpDevReturnValueCompat.h
@@ -1,0 +1,42 @@
+#ifndef YARP_DEV_RETURN_VALUE_COMPAT_H
+#define YARP_DEV_RETURN_VALUE_COMPAT_H
+
+// Defines YARP_VERSION_* macro
+#include <yarp/conf/version.h>
+
+// These macros simplify the migration of the devices implementation from YARP 3.11 to YARP 3.12,
+// where the interfaces migrated from using bool as return values to use yarp::dev::ReturnValue,
+// see https://github.com/robotology/yarp/discussions/3168
+//
+// The _CH312 suffix is used as this macro are used in the interface that migrated from bool
+// to yarp::dev::ReturnValue in YARP 3.12, if more interfaces will migrate in YARP 3.13
+// _CH313 macro could be added
+#if (YARP_VERSION_MAJOR > 3) || \
+    (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR > 11) || \
+    (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR == 11 && YARP_VERSION_PATCH >= 100)
+
+#define YARP_DEV_RETURN_VALUE_TYPE_CH312 yarp::dev::ReturnValue
+#define YARP_DEV_RETURN_VALUE_OK_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_ok)
+#define YARP_DEV_RETURN_VALUE_ERROR_GENERIC_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_generic)
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_not_implemented_by_device)
+#define YARP_DEV_RETURN_VALUE_ERROR_NWS_NWC_COMMUNICATION_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_nws_nwc_communication_error)
+#define YARP_DEV_RETURN_VALUE_ERROR_DEPRECATED_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_deprecated)
+#define YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_method_failed)
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_READY_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_not_ready)
+#define YARP_DEV_RETURN_VALUE_ERROR_UNITIALIZED_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_uninitialized)
+
+#else
+
+#define YARP_DEV_RETURN_VALUE_TYPE_CH312 bool
+#define YARP_DEV_RETURN_VALUE_OK_CH312 true
+#define YARP_DEV_RETURN_VALUE_ERROR_GENERIC_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_NWS_NWC_COMMUNICATION_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_DEPRECATED_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_READY_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_UNITIALIZED_CH312 false
+
+#endif
+
+#endif

--- a/plugins/laser/LaserDriver.cpp
+++ b/plugins/laser/LaserDriver.cpp
@@ -13,6 +13,9 @@
 #include <yarp/os/Searchable.h>
 #include <yarp/sig/Vector.h>
 
+#include <YarpDevReturnValueCompat.h>
+
+
 namespace yarp
 {
 namespace dev
@@ -75,7 +78,7 @@ public:
         return true;
     }
 
-    bool getRawData(yarp::sig::Vector& ranges, double* timestamp) override
+    YARP_DEV_RETURN_VALUE_TYPE_CH312 getRawData(yarp::sig::Vector& ranges, double* timestamp) override
     {
         std::lock_guard<std::mutex> lock(m_sensorData->m_mutex);
 
@@ -86,36 +89,36 @@ public:
         }
         *timestamp = m_sensorData->simTime;
 
-        return true;
+        return YARP_DEV_RETURN_VALUE_OK_CH312;
     }
 
     // IRangefinder2D
-    bool setDistanceRange(double min, double max) override
+    YARP_DEV_RETURN_VALUE_TYPE_CH312 setDistanceRange(double min, double max) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
         yError() << "setDistanceRange() Not yet implemented";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
-    bool setScanLimits(double min, double max) override
+    YARP_DEV_RETURN_VALUE_TYPE_CH312 setScanLimits(double min, double max) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
         yError() << "setScanLimits() Not yet implemented";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
-    bool setHorizontalResolution(double step) override
+    YARP_DEV_RETURN_VALUE_TYPE_CH312 setHorizontalResolution(double step) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
         yError() << "setHorizontalResolution() Not yet implemented";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
-    bool setScanRate(double rate) override
+    YARP_DEV_RETURN_VALUE_TYPE_CH312 setScanRate(double rate) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
         yError() << "setScanRate() Not yet implemented";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
     // ILaserData


### PR DESCRIPTION
This PR switches migrate the Laser plugin to the use of yarp::dev::ReturnValue-based interface, as a follow up of:
* https://github.com/robotology/yarp/discussions/3168
* https://github.com/robotology/yarp/pull/3180
* https://github.com/robotology/yarp-device-rplidar/pull/7

To avoid the need to keep two branches, one for compatibility with YARP 3.11.* and one for the future YARP 3.12.*, I prepared a `YarpDevReturnValueCompat.h` header that can be useful to implement an interface that works in both cases. As these header can be useful also for other repos, but I do not think it make sense to install in an a reusable library as it is a temporary solution, I will store it in https://gist.github.com/traversaro/ab7ab377c70c50d312a7b5edd4da6242, so that interested users can copy it in their repo as a private (non-installed) header to simplify the support of the future YARP 3.12