### PR TITLE
Fix setRefTorque doing nothing since 0.4.0 and torque feedback in coupled case when torque mapping methods are implemented

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(gz-sim-yarp-plugins
         LANGUAGES CXX C
-        VERSION 0.4.0)
+        VERSION 0.4.1)
 
 find_package(YARP REQUIRED COMPONENTS robotinterface os)
 find_package(YCM REQUIRED)

--- a/plugins/controlboard/src/ControlBoard.cpp
+++ b/plugins/controlboard/src/ControlBoard.cpp
@@ -479,7 +479,7 @@ bool ControlBoard::updateReferences(const UpdateInfo& _info, EntityComponentMana
         }
 
         m_controlBoardData.ijointcoupling->convertFromActuatedAxesToPhysicalJointsPos(m_actuatedAxesPositionBuffer, m_physicalJointsPositionBuffer);
-        m_controlBoardData.ijointcoupling->convertFromActuatedAxesToPhysicalJointsTrq(m_actuatedAxesTorqueBuffer, m_physicalJointsTorqueBuffer);
+        m_controlBoardData.ijointcoupling->convertFromActuatedAxesToPhysicalJointsTrq(m_actuatedAxesPositionBuffer, m_actuatedAxesTorqueBuffer, m_physicalJointsTorqueBuffer);
 
         for(auto i = 0; i < m_controlBoardData.physicalJoints.size(); i++)
         {


### PR DESCRIPTION
https://github.com/robotology/gz-sim-yarp-plugins/pull/221 contained a critical regression that got released in 0.4.0. Due to the coupling refactor, even in torque control mode calling `setRefTorque` was ignored, as the value `m_controlBoardData.actuatedAxes[i].commonJointProperties.refTorque` (that was set by `setRefTorque` was never copied in `m_controlBoardData.physicalJoints[i].commonJointProperties.refTorque` (that was the value eventually passed to the Gazebo simulation. The problem was detected and reported by @PasMarra in https://github.com/robotology/gz-sim-yarp-plugins/issues/245 .

This PR fixes this bug, and also:
* Fixes the `ControlBoardTorqueControlTest` to also check if the value set by `setRefTorque` is correctly propagated. The test was already using `setRefTorque`, but then it was not checking if the value set by `setRefTorque` was the value read by `getTorque`, so I added the check ` EXPECT_NEAR(jointTorque, motorTorque, acceptedTolerance);` to prevent further regression in the future. I also cleaned up some old debug prints, and reduced the iterations of the test from 1000 to 10, to reduce the time of the test from ~3 seconds to ~2 seconds (that it is still a lot, but that is another story). 
* Ensure that the torque reference and the torque feedback is correctly propagated also for coupled joints in the case the coupling exposes the required torque-related mapping, fixing part of https://github.com/robotology/gz-sim-yarp-plugins/issues/247 . See https://github.com/robotology/gz-sim-yarp-plugins/pull/248#pullrequestreview-2660646495 and https://github.com/robotology/gz-sim-yarp-plugins/pull/248#issuecomment-2700518363 for more details.

Fix https://github.com/robotology/gz-sim-yarp-plugins/issues/245
