### PR TITLE
Cleanup libGL conda dependencies

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -36,12 +36,12 @@ jobs:
       shell: bash -l {0}
       run: |
         # Additional dependencies only useful on Linux
-        # See https://github.com/robotology/robotology-superbuild/issues/477
-        micromamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
+        # See https://conda-forge.org/docs/maintainer/maintainer_faq/#how-do-i-fix-the-libglso1-import-error
+        micromamba install libgl-devel
         # Update package lists
         sudo apt-get update
         # See https://github.com/robotology/gz-yarp-plugins/pull/38#issuecomment-1681909589 for more info
-        sudo apt install libgl1 libgl1-mesa-dri libselinux1 libxdamage1 libxxf86vm1 libxext6 libopengl0 libegl1
+        sudo apt install libgl1-mesa-dri libglx-mesa0 libegl-mesa0
 
     - name: Configure VS Toolchain (Windows)
       if: contains(matrix.os, 'windows')


### PR DESCRIPTION
Since the `libgl` library was packaged in conda-forge, we can now just depend on it (and the related system-level OpenGL drivers, installed via apt) instead of rely on CDTs packages, see https://conda-forge.org/docs/maintainer/maintainer_faq/#how-do-i-fix-the-libglso1-import-error for upstream conda-forge documentation.