### PR TITLE
Added velocity control

### DIFF
--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -81,7 +81,7 @@ private:
     double getJointTorqueFromTransmittedWrench(const gz::sim::Joint& gzJoint,
                                                const gz::msgs::Wrench& wrench,
                                                const gz::sim::EntityComponentManager& ecm) const;
-    bool initializePIDsForPositionControl();
+    bool initializePIDs(yarp::dev::PidControlTypeEnum pid_type);
     bool tryGetGroup(const yarp::os::Bottle& in,
                      std::vector<double>& out,
                      const std::string& key,
@@ -92,7 +92,7 @@ private:
                           const std::string& paramName,
                           std::vector<yarp::dev::Pid>& yarpPIDs,
                           size_t numberOfPhysicalJoints);
-    void setJointPositionPIDs(AngleUnitEnum cUnits, const std::vector<yarp::dev::Pid>& yarpPIDs);
+    void setJointPIDs(AngleUnitEnum cUnits, const std::vector<yarp::dev::Pid>& yarpPIDs,yarp::dev::PidControlTypeEnum pid_type);
     double convertUserGainToGazeboGain(PhysicalJointProperties& joint, double value);
     double convertGazeboGainToUserGain(PhysicalJointProperties& joint, double value);
     double convertGazeboToUser(PhysicalJointProperties& joint, double value);

--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -93,10 +93,6 @@ private:
                           std::vector<yarp::dev::Pid>& yarpPIDs,
                           size_t numberOfPhysicalJoints);
     void setJointPIDs(AngleUnitEnum cUnits, const std::vector<yarp::dev::Pid>& yarpPIDs,yarp::dev::PidControlTypeEnum pid_type);
-    double convertUserGainToGazeboGain(PhysicalJointProperties& joint, double value);
-    double convertGazeboGainToUserGain(PhysicalJointProperties& joint, double value);
-    double convertGazeboToUser(PhysicalJointProperties& joint, double value);
-    double convertUserToGazebo(PhysicalJointProperties& joint, double value);
     bool initializeJointPositionLimits(const gz::sim::EntityComponentManager& ecm);
     bool initializeTrajectoryGenerators();
     bool initializeTrajectoryGeneratorReferences(yarp::os::Bottle& trajectoryGeneratorsGroup);

--- a/plugins/controlboard/include/ControlBoardData.hh
+++ b/plugins/controlboard/include/ControlBoardData.hh
@@ -67,8 +67,8 @@ struct ActuatedAxisProperties
 {
     CommonJointProperties commonJointProperties;
     std::unique_ptr<yarp::dev::gzyarp::TrajectoryGenerator> trajectoryGenerator;
-    std::unique_ptr<yarp::dev::gzyarp::RampFilter> speed_ramp_handler;
-    std::unique_ptr<yarp::dev::gzyarp::Watchdog> velocity_watchdog;
+    std::unique_ptr<yarp::dev::gzyarp::RampFilter> speedRampHandler;
+    std::unique_ptr<yarp::dev::gzyarp::Watchdog> velocityWatchdog;
     double trajectoryGenerationRefPosition{0.0};
     double trajectoryGenerationRefSpeed{0.0};
     double trajectoryGenerationRefAcceleration{0.0};
@@ -89,6 +89,11 @@ public:
     bool initCoupledJoints();
     bool setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode);
     bool setControlMode(int j, int mode);
+
+    static double convertUserGainToGazeboGain(PhysicalJointProperties& joint, double value);
+    static double convertGazeboGainToUserGain(PhysicalJointProperties& joint, double value);
+    static double convertGazeboToUser(PhysicalJointProperties& joint, double value);
+    static double convertUserToGazebo(PhysicalJointProperties& joint, double value);
 private:
     yarp::sig::VectorOf<size_t> coupledActuatedAxes, coupledPhysicalJoints;
 };

--- a/plugins/controlboard/include/ControlBoardData.hh
+++ b/plugins/controlboard/include/ControlBoardData.hh
@@ -45,7 +45,8 @@ struct CommonJointProperties {
     double zeroPosition{0.0}; // The zero position is the position of the GAZEBO joint that will be
                               // read as the starting one i.e.
                               // getEncoder(j)=m_zeroPosition+gazebo.getEncoder(j);
-    double refPosition{0.0};
+    double refPosition{0.0};  //for position control mode
+    double refVelocity{0.0};  //for velocity control mode
     double position{0.0}; // Joint position [deg]
     double positionLimitMin{std::numeric_limits<double>::min()};
     double positionLimitMax{std::numeric_limits<double>::max()};
@@ -66,6 +67,8 @@ struct ActuatedAxisProperties
 {
     CommonJointProperties commonJointProperties;
     std::unique_ptr<yarp::dev::gzyarp::TrajectoryGenerator> trajectoryGenerator;
+    std::unique_ptr<yarp::dev::gzyarp::RampFilter> speed_ramp_handler;
+    std::unique_ptr<yarp::dev::gzyarp::Watchdog> velocity_watchdog;
     double trajectoryGenerationRefPosition{0.0};
     double trajectoryGenerationRefSpeed{0.0};
     double trajectoryGenerationRefAcceleration{0.0};

--- a/plugins/controlboard/src/ControlBoardData.cpp
+++ b/plugins/controlboard/src/ControlBoardData.cpp
@@ -1,5 +1,6 @@
 
 #include <ControlBoardData.hh>
+#include <Common.hh>
 
 namespace gzyarp
 {
@@ -114,5 +115,28 @@ bool ControlBoardData::setControlMode(int j, int mode) {
         return true;
 }
 
+double ControlBoardData::convertGazeboGainToUserGain(PhysicalJointProperties& joint, double value)
+{
+    // TODO discriminate between joint types
+    return gzyarp::convertRadianGainToDegreeGains(value);
+}
+
+double ControlBoardData::convertGazeboToUser(PhysicalJointProperties& joint, double value)
+{
+    // TODO discriminate between joint types
+    return gzyarp::convertRadiansToDegrees(value);
+}
+
+double ControlBoardData::convertUserToGazebo(PhysicalJointProperties& joint, double value)
+{
+    // TODO discriminate between joint types
+    return gzyarp::convertDegreesToRadians(value);
+}
+
+double ControlBoardData::convertUserGainToGazeboGain(PhysicalJointProperties& joint, double value)
+{
+    // TODO discriminate between joint types
+    return gzyarp::convertDegreeGainToRadianGains(value);
+}
 
 } // namespace gzyarp


### PR DESCRIPTION
Added implementation for `VelocityMove()`, `setPid()`, `getPid()` methods.
Added velocityRamp filter (as implemented in gazebo-yarp-plugins). 

Tested using the yarpmotorgui to send continuous velocity references to the wheels of R1 model: https://github.com/icub-tech-iit/r1-models/tree/master/urdf/R1Mk3/robots/R1Mk3Gazebo. No significant changes to the velocity PID gains used by the model (https://github.com/icub-tech-iit/r1-models/blob/master/urdf/R1Mk3/conf/gazebo_cer_mobile_base.ini) respect to those employed with the classic gazebo.

