### PR TITLE
Do not skip anymore LaserTest and CameraTest in conda-forge CI

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -85,13 +85,12 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }}
 
     # Tests are Ubuntu-only due to  https://github.com/robotology/gz-sim-yarp-plugins/issues/215 and  https://github.com/robotology/gz-sim-yarp-plugins/issues/205
-    - name: Test_ubuntu
+    - name: Test
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build
-        # LaserTest and CameraTest are failing on conda-forge on Ubuntu: https://github.com/robotology/gz-sim-yarp-plugins/issues/196
-        ctest -E "^LaserTest|^CameraTest" --output-on-failure -C ${{ matrix.build_type }} .
+        ctest --output-on-failure -C ${{ matrix.build_type }} .
 
     - name: Install
       run: |


### PR DESCRIPTION
This change was already done in https://github.com/robotology/gz-sim-yarp-plugins/pull/199, but for some reason (not clear from the context) the PR was merged in the [`fixmoretests`](https://github.com/robotology/gz-sim-yarp-plugins/tree/fixmoretests) branch instead of `master`.

For reference, the original text of https://github.com/robotology/gz-sim-yarp-plugins/pull/199 was : 

> https://github.com/robotology/gz-sim-yarp-plugins/issues/196 was fixed by https://github.com/conda-forge/ogre-next-feedstock/pull/20, so we can enable this tests on Linux with conda-forge-provided dependencies.