### PR TITLE
ControlBoardPositionDirectControlTest: add check of getRefPositions

### DIFF
--- a/tests/controlboard/CMakeLists.txt
+++ b/tests/controlboard/CMakeLists.txt
@@ -9,7 +9,9 @@ set(TESTS
 
 foreach(TEST ${TESTS})
   add_executable(${TEST} ${TEST}.cc)
-
+  if (GZ_SIM_YARP_PLUGINS_ENABLE_TESTS_WITH_ICUB_MAIN)
+    target_compile_definitions(${TEST} PRIVATE GZ_SIM_YARP_PLUGINS_ENABLE_TESTS_WITH_ICUB_MAIN)
+  endif()
   target_link_libraries(${TEST}
     PRIVATE GTest::gtest_main
             test-helpers

--- a/tests/controlboard/ControlBoardPositionDirectControlTest.cc
+++ b/tests/controlboard/ControlBoardPositionDirectControlTest.cc
@@ -219,19 +219,24 @@ TEST_F(ControlBoardPositionDirectFixture, CheckPositionTrackingUsingPendulumMode
         refTrajectory[i] = value;
     }
 
-    double jointPosition;
+    double jointPosition, jointRefPosition;
 
     testFixture
         .OnPreUpdate([&](const gz::sim::UpdateInfo& _info, gz::sim::EntityComponentManager& _ecm) {
             // Set ref position
             iPositionDirectControl->setPosition(0, refTrajectory[iterations]);
+            iPositionDirectControl->getRefPosition(0, &jointRefPosition);
+            EXPECT_EQ(refTrajectory[iterations], jointRefPosition);
+
+            std::cerr << "Joint 0 ref position: " << jointRefPosition << std::endl;
+            std::cerr << "Joint 0 position: " << jointPosition << std::endl;
+
         })
         .OnPostUpdate(
             [&](const gz::sim::UpdateInfo& _info, const gz::sim::EntityComponentManager& _ecm) {
                 // std::cerr << "========== Iteration: " << iterations << std::endl;
 
                 iEncoders->getEncoder(0, &jointPosition);
-
                 // std::cerr << "ref position: " << refTrajectory[iterations] << std::endl;
                 // std::cerr << "joint position: " << jointPosition << std::endl;
 
@@ -277,20 +282,23 @@ TEST_F(ControlBoardPositionDirectCoupledPendulumFixture, CheckPositionTrackingUs
         refTrajectory[i] = value;
     }
 
-    yarp::sig::Vector jointPositions{0.0, 0.0};
+    yarp::sig::Vector jointPositions{0.0, 0.0}, jointRefPositions{0.0, 0.0};
 
     testFixture
         .OnPreUpdate([&](const gz::sim::UpdateInfo& _info, gz::sim::EntityComponentManager& _ecm) {
             // Set ref position
             iPositionDirectControl->setPosition(0, refTrajectory[iterations]);
             iPositionDirectControl->setPosition(1, refTrajectory[iterations]);
+            iPositionDirectControl->getRefPositions(jointRefPositions.data());
+            EXPECT_EQ(refTrajectory[iterations], jointRefPositions[0]);
+            EXPECT_EQ(refTrajectory[iterations], jointRefPositions[1]);
         })
         .OnPostUpdate(
             [&](const gz::sim::UpdateInfo& _info, const gz::sim::EntityComponentManager& _ecm) {
                 // std::cerr << "========== Iteration: " << iterations << std::endl;
 
                 iEncoders->getEncoders(jointPositions.data());
-                
+
                 // std::cerr << "ref position: " << refTrajectory[iterations] << std::endl;
                 // std::cerr << "joint position: " << jointPosition << std::endl;
 

--- a/tests/controlboard/ControlBoardPositionDirectControlTest.cc
+++ b/tests/controlboard/ControlBoardPositionDirectControlTest.cc
@@ -248,9 +248,6 @@ TEST_F(ControlBoardPositionDirectFixture, CheckPositionTrackingUsingPendulumMode
             iPositionDirectControl->getRefPosition(0, &jointRefPosition);
             EXPECT_EQ(refTrajectory[iterations], jointRefPosition);
 
-            // std::cerr << "Joint 0 ref position: " << jointRefPosition << std::endl;
-            // std::cerr << "Joint 0 position: " << jointPosition << std::endl;
-
         })
         .OnPostUpdate(
             [&](const gz::sim::UpdateInfo& _info, const gz::sim::EntityComponentManager& _ecm) {

--- a/tests/controlboard/ControlBoardPositionDirectControlTest.cc
+++ b/tests/controlboard/ControlBoardPositionDirectControlTest.cc
@@ -165,6 +165,7 @@ protected:
 
                 prop.addGroup("axesNames");
                 auto& botAxesList = prop.findGroup("axesNames").addList();
+                botAxesList.addString("fixed_base");
                 botAxesList.addString("upper_joint");
                 botAxesList.addString("lower_joint");
 
@@ -288,7 +289,7 @@ TEST_F(ControlBoardPositionDirectFixture, CheckPositionTrackingUsingPendulumMode
     std::cerr << "Average tracking error: " << avgTrackgingError << std::endl;
     EXPECT_LT(avgTrackgingError, acceptedTolerance);
 }
-
+#if defined GZ_SIM_YARP_PLUGINS_ENABLE_TESTS_WITH_ICUB_MAIN
 TEST_F(ControlBoardPositionDirectCoupledPendulumFixture, CheckPositionTrackingUsingCoupledPendulumModel)
 {
     // Generate ref trajectory
@@ -360,6 +361,8 @@ TEST_F(ControlBoardPositionDirectCoupledPendulumFixture, CheckPositionTrackingUs
     EXPECT_LT(avgTrackgingError0, acceptedTolerance);
     EXPECT_LT(avgTrackgingError1, acceptedTolerance);
 }
+
+#endif // GZ_SIM_YARP_PLUGINS_ENABLE_TESTS_WITH_ICUB_MAIN
 
 } // namespace test
 } // namespace gzyarp

--- a/tests/controlboard/conf/coupled_pendulum_nws.xml
+++ b/tests/controlboard/conf/coupled_pendulum_nws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="coupled_pendulum" portprefix="coupled_pendulum" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="coupled_pendulum_nws_yarp" type="controlBoard_nws_yarp">
+            <!-- See https://www.yarp.it/latest/classControlBoard__nws__yarp.html for parameter documentation -->
+            <param name="name"> /coupledPendulumGazebo/body </param>
+            <param name="period"> 0.01 </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the gazebo_controlboard plugin -->
+                <param name="device"> controlboard_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tests/controlboard/conf/gazebo_controlboard_multiple_joints.ini
+++ b/tests/controlboard/conf/gazebo_controlboard_multiple_joints.ini
@@ -20,15 +20,15 @@ stictionDwn   (0.0      0.0)
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 velocityControlImplementationType integrator_and_position_pid
-kp            (500.0)
-kd            (2.0)
-ki            (0.1)
-maxInt        (9999)
-maxOutput     (9999)
-shift         (0.0)
-ko            (0.0)
-stictionUp    (0.0)
-stictionDwn   (0.0)
+kp            (500.0 500.0)
+kd            (2.0 2.0)
+ki            (0.1 0.1)
+maxInt        (9999 9999)
+maxOutput     (9999 9999)
+shift         (0.0 0.0)
+ko            (0.0 0.0)
+stictionUp    (0.0 0.0)
+stictionDwn   (0.0 0.0)
 
 [LIMITS]
 jntPosMax (200.0 10.0)

--- a/tests/controlboard/coupled_pendulum_two_controlboards.sdf
+++ b/tests/controlboard/coupled_pendulum_two_controlboards.sdf
@@ -171,9 +171,9 @@
         </yarpConfigurationFile>
         <initialConfiguration>0.0</initialConfiguration>
       </plugin>
-      <!-- <plugin name='robotinterface' filename='libgazebo_yarp_robotinterface.so'>
-      <yarpRobotInterfaceConfigurationFile>model://coupled_pendulum/conf/coupled_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
-      </plugin> -->
+      <plugin name='robotinterface' filename='libgazebo_yarp_robotinterface.so'>
+      <yarpRobotInterfaceConfigurationFile>model://coupled_pendulum/conf/coupled_pendulum_nwsdafsads.xml</yarpRobotInterfaceConfigurationFile>
+      </plugin>
 
       <frame name='fake_base_fixed_joint' attached_to='base_link'>
         <pose>0 0 0 0 0 0</pose>

--- a/tests/controlboard/coupled_pendulum_two_joints_coupled.sdf
+++ b/tests/controlboard/coupled_pendulum_two_joints_coupled.sdf
@@ -46,6 +46,24 @@
     </model>
 
     <model name="coupled_pendulum">
+      <joint name="fixed_base" type="revolute">
+          <parent>world</parent>
+          <child>base_link</child>
+          <axis>
+              <xyz>1 0 0</xyz>
+              <limit>
+                  <lower>-5</lower>
+                  <upper>5</upper>
+                  <effort>100</effort>
+                  <velocity>100</velocity>
+              </limit>
+              <dynamics>
+                  <damping>0.0</damping>
+                  <spring_reference>0</spring_reference>
+                  <spring_stiffness>0.0</spring_stiffness>
+              </dynamics>
+          </axis>
+      </joint>
       <link name='base_link'>
         <inertial>
           <pose>0 0 0 0 0 0</pose>
@@ -161,13 +179,13 @@
 
       <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
         <yarpConfigurationFile>
-          model://conf/gazebo_controlboard_multiple_joints.ini
+          model://conf/gazebo_controlboard_coupling.ini
         </yarpConfigurationFile>
         <initialConfiguration>0.0</initialConfiguration>
       </plugin>
-      <!-- <plugin name='robotinterface' filename='libgazebo_yarp_robotinterface.so'>
-      <yarpRobotInterfaceConfigurationFile>model://coupled_pendulum/conf/coupled_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
-      </plugin> -->
+      <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
+      <yarpRobotInterfaceConfigurationFile>model://conf/coupled_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
+      </plugin>
 
       <frame name='fake_base_fixed_joint' attached_to='base_link'>
         <pose>0 0 0 0 0 0</pose>


### PR DESCRIPTION
Moreover it enables the test of the coupling if `icub-main` is found

xref: 
- #260 