### PR TITLE
Fix IMU orientation export

### DIFF
--- a/plugins/imu/Imu.cc
+++ b/plugins/imu/Imu.cc
@@ -1,3 +1,4 @@
+#include <Common.hh>
 #include <ConfigurationHelpers.hh>
 #include <DeviceRegistry.hh>
 #include <ImuDriver.cpp>
@@ -171,9 +172,19 @@ public:
             imuMsg = this->imuMsg;
         }
         std::lock_guard<std::mutex> lock(imuData.m_mutex);
-        imuData.m_data[0] = (imuMsg.orientation().x() != 0) ? imuMsg.orientation().x() : 0;
-        imuData.m_data[1] = (imuMsg.orientation().y() != 0) ? imuMsg.orientation().y() : 0;
-        imuData.m_data[2] = (imuMsg.orientation().w() != 0) ? imuMsg.orientation().w() : 0;
+
+        // Convert quaternion to RPY
+        gz::math::Quaterniond q(imuMsg.orientation().w(),
+                                imuMsg.orientation().x(),
+                                imuMsg.orientation().y(),
+                                imuMsg.orientation().z());
+        double roll = q.Roll();
+        double pitch = q.Pitch();
+        double yaw = q.Yaw();
+
+        imuData.m_data[0] = convertDegreesToRadians(roll);
+        imuData.m_data[1] = convertDegreesToRadians(pitch);
+        imuData.m_data[2] = convertDegreesToRadians(yaw);
         imuData.m_data[3]
             = (imuMsg.linear_acceleration().x() != 0) ? imuMsg.linear_acceleration().x() : 0;
         imuData.m_data[4]

--- a/tests/imu/ImuTest.cc
+++ b/tests/imu/ImuTest.cc
@@ -114,7 +114,7 @@ TEST_F(ImuFixture, ImuTest)
 
     EXPECT_NEAR(measureOrientation(0), 0.0, 1e-2);
     EXPECT_NEAR(measureOrientation(1), 0.0, 1e-2);
-    EXPECT_NEAR(measureOrientation(2), 1.0, 1e-2);
+    EXPECT_NEAR(measureOrientation(2), 0.0, 1e-2);
     EXPECT_GT(timestampOrientation, 0.0);
 
     EXPECT_NEAR(measureAccelerometer(0), 0.0, 1e-2);


### PR DESCRIPTION
This PR fixes a bug in how the orientation given from a gz-sim IMU sensor is read and exposed via the [IOrientationSensors](https://www.yarp.it/latest/classyarp_1_1dev_1_1IOrientationSensors.html#adb2a40d03c747aa9c8b7fc542f193fd9) interface.