### PR TITLE
Parse `jntVelMax` in controlboard's config

### DIFF
--- a/plugins/controlboard/include/ControlBoard.hh
+++ b/plugins/controlboard/include/ControlBoard.hh
@@ -94,6 +94,7 @@ private:
                           size_t numberOfPhysicalJoints);
     void setJointPIDs(AngleUnitEnum cUnits, const std::vector<yarp::dev::Pid>& yarpPIDs,yarp::dev::PidControlTypeEnum pid_type);
     bool initializeJointPositionLimits(const gz::sim::EntityComponentManager& ecm);
+    bool initializeJointVelocityLimits(const gz::sim::EntityComponentManager& ecm);
     bool initializeTrajectoryGenerators();
     bool initializeTrajectoryGeneratorReferences(yarp::os::Bottle& trajectoryGeneratorsGroup);
     bool parseInitialConfiguration(std::vector<double>& initialConfigurations);


### PR DESCRIPTION
Optionally parses `jntVelMax` inside a `[LIMITS]` group, as in [gazebo-yarp-plugins](https://github.com/robotology/gazebo-yarp-plugins/blob/f837061bab745e30fa40863e8ae8ce063320d5fe/plugins/controlboard/src/ControlBoardDriver.cpp#L899-L935).