### PR TITLE
LaserDriver fix

### DIFF
--- a/plugins/laser/Laser.cc
+++ b/plugins/laser/Laser.cc
@@ -117,7 +117,6 @@ public:
                                                components::Sensor());
 
         sensorScopedName = scopedName(this->sensor, _ecm);
-        this->laserData.sensorScopedName = sensorScopedName;
 
         driver_properties.put(YarpLaserScopedName.c_str(), sensorScopedName.c_str());
 
@@ -129,16 +128,15 @@ public:
             return;
         }
 
-        ILaserData* iLaserData = nullptr;
-        auto viewOk = m_laserDriver.view(iLaserData);
+        auto viewOk = m_laserDriver.view(m_iLaserData);
 
-        if (!viewOk || !iLaserData)
+        if (!viewOk || !m_iLaserData)
         {
             yError() << "gz-sim-yarp-laser-system Plugin failed: error in getting "
                         "ILaserData interface";
             return;
         }
-        iLaserData->setLaserData(&laserData);
+        //m_iLaserData->setLaserData(&m_laserData);
 
         auto yarpDeviceNamee = driver_properties.find("yarpDeviceName").asString();
 
@@ -170,24 +168,23 @@ public:
         gz::msgs::LaserScan laserMsg;
         {
             std::lock_guard<std::mutex> lock(this->laserMsgMutex);
-            laserMsg = this->laserMsg;
+            laserMsg = m_laserMsg;
         }
 
-        std::lock_guard<std::mutex> lock(laserData.m_mutex);
-        laserData.m_data.resize(laserMsg.ranges().size());
-
+        m_laserData.m_data.resize(laserMsg.ranges().size());
         for (size_t i = 0; i < laserMsg.ranges().size(); i++)
         {
-            laserData.m_data[i] = laserMsg.ranges(i);
+            m_laserData.m_data[i] = laserMsg.ranges(i);
         }
+        m_laserData.m_simTime = _info.simTime.count() / 1e9;
 
-        laserData.simTime = _info.simTime.count() / 1e9;
+        m_iLaserData->setLaserData(&m_laserData);
     }
 
     void laserCb(const gz::msgs::LaserScan& _msg)
     {
         std::lock_guard<std::mutex> lock(this->laserMsgMutex);
-        laserMsg = _msg;
+        m_laserMsg = _msg;
     }
 
 private:
@@ -196,12 +193,13 @@ private:
     std::string m_deviceId;
     std::string sensorScopedName;
     bool m_deviceRegistered;
-    LaserData laserData;
+    LaserData m_laserData;
     bool laserInitialized{false};
     gz::transport::Node node;
-    gz::msgs::LaserScan laserMsg;
+    gz::msgs::LaserScan m_laserMsg;
     std::mutex laserMsgMutex;
     EntityComponentManager* ecm;
+    ILaserData* m_iLaserData = nullptr;
 };
 
 } // namespace gzyarp

--- a/plugins/laser/Laser.cc
+++ b/plugins/laser/Laser.cc
@@ -136,7 +136,6 @@ public:
                         "ILaserData interface";
             return;
         }
-        //m_iLaserData->setLaserData(&m_laserData);
 
         auto yarpDeviceNamee = driver_properties.find("yarpDeviceName").asString();
 
@@ -171,14 +170,14 @@ public:
             laserMsg = m_laserMsg;
         }
 
-        m_laserData.m_data.resize(laserMsg.ranges().size());
+        m_gzlaserData.m_data.resize(laserMsg.ranges().size());
         for (size_t i = 0; i < laserMsg.ranges().size(); i++)
         {
-            m_laserData.m_data[i] = laserMsg.ranges(i);
+            m_gzlaserData.m_data[i] = laserMsg.ranges(i);
         }
-        m_laserData.m_simTime = _info.simTime.count() / 1e9;
+        m_gzlaserData.m_simTime = _info.simTime.count() / 1e9;
 
-        m_iLaserData->setLaserData(&m_laserData);
+        m_iLaserData->updateLaserMeasurements(m_gzlaserData);
     }
 
     void laserCb(const gz::msgs::LaserScan& _msg)
@@ -193,7 +192,7 @@ private:
     std::string m_deviceId;
     std::string sensorScopedName;
     bool m_deviceRegistered;
-    LaserData m_laserData;
+    LaserData m_gzlaserData;
     bool laserInitialized{false};
     gz::transport::Node node;
     gz::msgs::LaserScan m_laserMsg;

--- a/plugins/laser/LaserDriver.cpp
+++ b/plugins/laser/LaserDriver.cpp
@@ -28,6 +28,10 @@ class LaserDriver;
 
 const std::string YarpLaserScopedName = "sensorScopedName";
 
+namespace {
+YARP_LOG_COMPONENT(GZ_SIM_LIDAR, "gzyarp.LaserDriver")
+}
+
 class yarp::dev::gzyarp::LaserDriver : public yarp::dev::Lidar2DDeviceBase,
                                        public yarp::dev::DeviceDriver,
                                        public ::gzyarp::ILaserData
@@ -45,6 +49,7 @@ public:
     {
         std::string sensorScopedName(config.find(YarpLaserScopedName.c_str()).asString().c_str());
 
+        /*
         std::string separator = "/";
         auto pos = config.find("sensor_name").asString().find_last_of(separator);
         if (pos == std::string::npos)
@@ -55,13 +60,14 @@ public:
             m_sensorName = config.find("sensor_name").asString().substr(pos + separator.size() - 1);
         }
         m_frameName = m_sensorName;
-
+        */
+        
         if (this->parseConfiguration(config) == false)
         {
-            yError() << "error parsing parameters";
+            yCError(GZ_SIM_LIDAR) << "error parsing parameters";
             return false;
         }
-        m_device_status = yarp::dev::IRangefinder2D::Device_status::DEVICE_OK_IN_USE;
+        m_device_status = yarp::dev::IRangefinder2D::Device_status::DEVICE_OK_STANDBY;
 
         return true;
     }
@@ -77,58 +83,69 @@ public:
         return true;
     }
 
-    YARP_DEV_RETURN_VALUE_TYPE_CH312 getRawData(yarp::sig::Vector& ranges, double* timestamp) override
-    {
-        std::lock_guard<std::mutex> lock(m_sensorData->m_mutex);
-
-        ranges.resize(m_sensorData->m_data.size(), 0.0);
-        for (size_t i = 0; i < m_sensorData->m_data.size(); i++)
-        {
-            ranges[i] = m_sensorData->m_data[i];
-        }
-        *timestamp = m_sensorData->simTime;
-
-        return YARP_DEV_RETURN_VALUE_OK_CH312;
-    }
-
     // IRangefinder2D
     YARP_DEV_RETURN_VALUE_TYPE_CH312 setDistanceRange(double min, double max) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
-        yError() << "setDistanceRange() Not yet implemented";
+        yCError(GZ_SIM_LIDAR) << "setDistanceRange() Not yet implemented";
         return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
     YARP_DEV_RETURN_VALUE_TYPE_CH312 setScanLimits(double min, double max) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
-        yError() << "setScanLimits() Not yet implemented";
+        yCError(GZ_SIM_LIDAR) << "setScanLimits() Not yet implemented";
         return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
     YARP_DEV_RETURN_VALUE_TYPE_CH312 setHorizontalResolution(double step) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
-        yError() << "setHorizontalResolution() Not yet implemented";
+        yCError(GZ_SIM_LIDAR) << "setHorizontalResolution() Not yet implemented";
         return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
     YARP_DEV_RETURN_VALUE_TYPE_CH312 setScanRate(double rate) override
     {
         std::lock_guard<std::mutex> guard(m_mutex);
-        yError() << "setScanRate() Not yet implemented";
+        yCError(GZ_SIM_LIDAR) << "setScanRate() Not yet implemented";
         return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
     }
 
     // ILaserData
-
     void setLaserData(::gzyarp::LaserData* dataPtr) override
     {
-        m_sensorData = dataPtr;
+        if (dataPtr==nullptr) return;
+        
+        std::lock_guard<std::mutex> guard(m_mutex);
+        
+        ::gzyarp::LaserData* sensorData = dataPtr;
+
+        if (sensorData->m_data.size() == 0)
+        {
+           yCErrorThrottle(GZ_SIM_LIDAR, 3.0) << "No data received, simulation not started yet?";
+           m_device_status = yarp::dev::IRangefinder2D::Device_status::DEVICE_GENERAL_ERROR;
+           return;    
+        }
+        else if (sensorData->m_data.size() != m_laser_data.size())
+        {
+           yCErrorThrottle(GZ_SIM_LIDAR, 3.0)  << "Data size error, expected: " << m_laser_data.size() 
+                                << " samples, got: " << sensorData->m_data.size();
+           m_device_status = yarp::dev::IRangefinder2D::Device_status::DEVICE_GENERAL_ERROR;
+           return;
+        }
+
+        for (size_t i = 0; i < sensorData->m_data.size(); i++)
+        {
+            m_laser_data[i] = sensorData->m_data[i];
+        }
+        this->applyLimitsOnLaserData();
+        
+        m_timestamp.update(sensorData->m_simTime);
+        m_device_status = yarp::dev::IRangefinder2D::Device_status::DEVICE_OK_IN_USE;
     }
 
 private:
-    ::gzyarp::LaserData* m_sensorData;
-    std::string m_sensorName;
-    std::string m_frameName;
+    //std::string m_sensorName;
+    //std::string m_frameName;
 };

--- a/plugins/laser/LaserShared.hh
+++ b/plugins/laser/LaserShared.hh
@@ -9,10 +9,8 @@ namespace gzyarp
 
 struct LaserData
 {
-    std::mutex m_mutex;
     std::vector<double> m_data;
-    std::string sensorScopedName;
-    double simTime;
+    double              m_simTime;
 };
 
 class ILaserData

--- a/plugins/laser/LaserShared.hh
+++ b/plugins/laser/LaserShared.hh
@@ -16,7 +16,7 @@ struct LaserData
 class ILaserData
 {
 public:
-    virtual void setLaserData(LaserData* dataPtr) = 0;
+    virtual void updateLaserMeasurements(const LaserData& gzdata) = 0;
 
     virtual ~ILaserData() {};
 };


### PR DESCRIPTION
This PR fixes the measurements of the Lidar device, by calling the method: `Lidar2DDeviceBase::applyLimitsOnLaserData()`

Previously, the `LaserDriver` class inherited from `Lidar2DDeviceBase`, but it did not utilize any of its methods or internal variables. Some extra checks are also added, verifying that the values provided in the Yarp configuration file and the sensor properties in the sdf are compatible. 