### PR TITLE
Add find_dependency(YARP COMPONENTS robotinterface os) in gz-sim-yarp-plugins CMake config

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -102,4 +102,4 @@ jobs:
       run: |
         cd build
         export CMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install
-        cmake-package-check gz-sim-yarp-plugins --targets gz-sim-yarp-plugins::gz-sim-yarp-device-registry
+        cmake-package-check gz-sim-yarp-plugins --targets gz-sim-yarp-plugins::gz-sim-yarp-device-registry gz-sim-yarp-plugins::gz-sim-yarp-commons

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ Install_basic_package_files(${PROJECT_NAME}
                             COMPATIBILITY AnyNewerVersion
                             VARS_PREFIX ${PROJECT_NAME}
                             NO_CHECK_REQUIRED_COMPONENTS_MACRO
-                            DEPENDENCIES "YARP" "gz-sim${GZ_SIM_VER}")
+                            DEPENDENCIES "YARP COMPONENTS robotinterface os" "gz-sim${GZ_SIM_VER}")
 
 # Add the uninstall target
 include(AddUninstallTarget)


### PR DESCRIPTION
Without thix, `find_package(gz-sim-yarp-plugins)` and then using the `gz-sim-yarp-plugins::gz-sim-yarp-commons` target fails with:

~~~
 │ -- Configuring done (7.5s)
 │ CMake Error at $SRC_DIR_run_env/lib/cmake/gz-sim-yarp-plugins/gz-sim-yarp-pluginsTargets.cmake:61 (set_target_properties):
 │   The link interface of target "gz-sim-yarp-plugins::gz-sim-yarp-commons"
 │   contains:
 │     YARP::YARP_robotinterface
 │   but the target was not found.  Possible reasons include:
 │     * There is a typo in the target name.
 │     * A find_package call is missing for an IMPORTED target.
 │     * An ALIAS target is missing.
 │ Call Stack (most recent call first):
 │   $SRC_DIR_run_env/lib/cmake/gz-sim-yarp-plugins/gz-sim-yarp-pluginsConfig.cmake:28 (include)
 │   CMakeLists.txt:5 (find_package)
~~~