### PR TITLE
Add YARP 4.0.0 support for controlboard plugin

### DIFF
--- a/plugins/controlboard/include/ControlBoardDriver.hh
+++ b/plugins/controlboard/include/ControlBoardDriver.hh
@@ -3,6 +3,7 @@
 #include <ControlBoardData.hh>
 
 #include <string>
+#include <vector>
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IAxisInfo.h>
@@ -19,6 +20,7 @@
 #include <yarp/dev/IVelocityControl.h>
 #include <yarp/dev/PidEnums.h>
 #include <yarp/os/Searchable.h>
+#include <gzyarp/YarpDevReturnValueCompat.h>
 
 namespace yarp
 {
@@ -52,156 +54,159 @@ public:
 
     // IAxisInfo
 
-    bool getAxisName(int axis, std::string& name) override;
-    bool getJointType(int axis, yarp::dev::JointTypeEnum& type) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getAxisName(int axis, std::string& name) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getJointType(int axis, yarp::dev::JointTypeEnum& type) override;
 
     // IEncodersTimed
 
-    bool resetEncoder(int j) override;
-    bool resetEncoders() override;
-    bool setEncoder(int j, double val) override;
-    bool setEncoders(const double* vals) override;
-    bool getEncoder(int j, double* v) override;
-    bool getEncoders(double* encs) override;
-    bool getEncoderSpeed(int j, double* sp) override;
-    bool getEncoderSpeeds(double* spds) override;
-    bool getEncoderAcceleration(int j, double* spds) override;
-    bool getEncoderAccelerations(double* accs) override;
-    bool getEncodersTimed(double* encs, double* time) override;
-    bool getEncoderTimed(int j, double* encs, double* time) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 resetEncoder(int j) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 resetEncoders() override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setEncoder(int j, double val) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setEncoders(const double* vals) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoder(int j, double* v) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoders(double* encs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoderSpeed(int j, double* sp) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoderSpeeds(double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoderAcceleration(int j, double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoderAccelerations(double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncodersTimed(double* encs, double* time) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getEncoderTimed(int j, double* encs, double* time) override;
 
     // IInteractionMode
 
-    bool getInteractionMode(int axis, yarp::dev::InteractionModeEnum* mode) override;
-    bool
-    getInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
-    bool getInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
-    bool setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode) override;
-    bool
-    setInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
-    bool setInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getInteractionMode(int axis, yarp::dev::InteractionModeEnum* mode) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setInteractionModes(int n_joints, int* joints, yarp::dev::InteractionModeEnum* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setInteractionModes(yarp::dev::InteractionModeEnum* modes) override;
 
     // IControlMode
 
-    bool getControlMode(int j, int* mode) override;
-    bool getControlModes(int* modes) override;
-    bool getControlModes(const int n_joint, const int* joints, int* modes) override;
-    bool setControlMode(const int j, const int mode) override;
-    bool setControlModes(const int n_joint, const int* joints, int* modes) override;
-    bool setControlModes(int* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getControlMode(int j, int* mode) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getControlModes(int* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getControlModes(const int n_joint, const int* joints, int* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setControlMode(const int j, const int mode) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setControlModes(const int n_joint, const int* joints, int* modes) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setControlModes(int* modes) override;
 
     // IControlLimits
 
-    bool setLimits(int axis, double min, double max) override;
-    bool getLimits(int axis, double* min, double* max) override;
-    bool setVelLimits(int axis, double min, double max) override;
-    bool getVelLimits(int axis, double* min, double* max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPosLimits(int axis, double min, double max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPosLimits(int axis, double* min, double* max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setVelLimits(int axis, double min, double max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getVelLimits(int axis, double* min, double* max) override;
 
     // IRemoteVariables
 
-    bool getRemoteVariable(std::string key, yarp::os::Bottle& val) override;
-    bool setRemoteVariable(std::string key, const yarp::os::Bottle& val) override;
-    bool getRemoteVariablesList(yarp::os::Bottle* listOfKeys) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRemoteVariable(std::string key, yarp::os::Bottle& val) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRemoteVariable(std::string key, const yarp::os::Bottle& val) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRemoteVariablesList(yarp::os::Bottle* listOfKeys) override;
 
     // ITorqueControl
 
-    bool getAxes(int* ax) override;
-    bool getRefTorques(double* t) override;
-    bool getRefTorque(int j, double* t) override;
-    bool setRefTorques(const double* t) override;
-    bool setRefTorque(int j, double t) override;
-    bool setRefTorques(const int n_joint, const int* joints, const double* t) override;
-    bool getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params) override;
-    bool setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params) override;
-    bool getTorque(int j, double* t) override;
-    bool getTorques(double* t) override;
-    bool getTorqueRange(int j, double* min, double* max) override;
-    bool getTorqueRanges(double* min, double* max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getAxes(int* ax) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefTorques(double* t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefTorque(int j, double* t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefTorques(const double* t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefTorque(int j, double t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefTorques(const int n_joint, const int* joints, const double* t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTorque(int j, double* t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTorques(double* t) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTorqueRange(int j, double* min, double* max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTorqueRanges(double* min, double* max) override;
 
     // IPositionDirect
 
-    bool setPosition(int j, double ref) override;
-    bool setPositions(const int n_joint, const int* joints, const double* refs) override;
-    bool setPositions(const double* refs) override;
-    bool getRefPosition(const int joint, double* ref) override;
-    bool getRefPositions(double* refs) override;
-    bool getRefPositions(const int n_joint, const int* joints, double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPosition(int j, double ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPositions(const int n_joint, const int* joints, const double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPositions(const double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefPosition(const int joint, double* ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefPositions(double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefPositions(const int n_joint, const int* joints, double* refs) override;
 
     // IPositionControl
 
-    bool positionMove(int j, double ref) override;
-    bool positionMove(const double* refs) override;
-    bool relativeMove(int j, double delta) override;
-    bool relativeMove(const double* deltas) override;
-    bool checkMotionDone(int j, bool* flag) override;
-    bool checkMotionDone(bool* flag) override;
-    bool setRefSpeed(int j, double sp) override;
-    bool setRefSpeeds(const double* spds) override;
-    bool setRefAcceleration(int j, double acc) override;
-    bool setRefAccelerations(const double* accs) override;
-    bool getRefSpeed(int j, double* ref) override;
-    bool getRefSpeeds(double* spds) override;
-    bool getRefAcceleration(int j, double* acc) override;
-    bool getRefAccelerations(double* accs) override;
-    bool stop(int j) override;
-    bool stop() override;
-    bool positionMove(const int n_joint, const int* joints, const double* refs) override;
-    bool relativeMove(const int n_joint, const int* joints, const double* deltas) override;
-    bool checkMotionDone(const int n_joint, const int* joints, bool* flag) override;
-    bool setRefSpeeds(const int n_joint, const int* joints, const double* spds) override;
-    bool setRefAccelerations(const int n_joint, const int* joints, const double* accs) override;
-    bool getRefSpeeds(const int n_joint, const int* joints, double* spds) override;
-    bool getRefAccelerations(const int n_joint, const int* joints, double* accs) override;
-    bool stop(const int n_joint, const int* joints) override;
-    bool getTargetPosition(const int joint, double* ref) override;
-    bool getTargetPositions(double* refs) override;
-    bool getTargetPositions(const int n_joint, const int* joints, double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 positionMove(int j, double ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 positionMove(const double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 relativeMove(int j, double delta) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 relativeMove(const double* deltas) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(int j, bool* flag) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(bool* flag) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajSpeed(int j, double sp) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajSpeeds(const double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajAcceleration(int j, double acc) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajAccelerations(const double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajSpeed(int j, double* ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajSpeeds(double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajAcceleration(int j, double* acc) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajAccelerations(double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop(int j) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop() override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 positionMove(const int n_joint, const int* joints, const double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 relativeMove(const int n_joint, const int* joints, const double* deltas) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(const int n_joint, const int* joints, bool* flag) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajSpeeds(const int n_joint, const int* joints, const double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajAccelerations(const int n_joint, const int* joints, const double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajSpeeds(const int n_joint, const int* joints, double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajAccelerations(const int n_joint, const int* joints, double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop(const int n_joint, const int* joints) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPosition(const int joint, double* ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPositions(double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPositions(const int n_joint, const int* joints, double* refs) override;
 
     // IVelocityControl
 
-    bool velocityMove(int j, double sp) override;
-    bool velocityMove(const double* sp) override;
-    bool velocityMove(const int n_joint, const int* joints, const double* spds) override;
-    bool getRefVelocity(const int joint, double* vel) override;
-    bool getRefVelocities(double* vels) override;
-    bool getRefVelocities(const int n_joint, const int* joints, double* vels) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 velocityMove(int j, double sp) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 velocityMove(const double* sp) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 velocityMove(const int n_joint, const int* joints, const double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetVelocity(const int joint, double* vel) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetVelocities(double* vels) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetVelocities(const int n_joint, const int* joints, double* vels) override;
 
     // ICurrentControl
 
-    bool getNumberOfMotors(int* ax) override;
-    bool getCurrent(int m, double* curr) override;
-    bool getCurrents(double* currs) override;
-    bool getCurrentRange(int m, double* min, double* max) override;
-    bool getCurrentRanges(double* min, double* max) override;
-    bool setRefCurrents(const double* currs) override;
-    bool setRefCurrent(int m, double curr) override;
-    bool setRefCurrents(const int n_motor, const int* motors, const double* currs) override;
-    bool getRefCurrents(double* currs) override;
-    bool getRefCurrent(int m, double* curr) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getNumberOfMotors(int* ax) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getCurrent(int m, double* curr) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getCurrents(double* currs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getCurrentRange(int m, double* min, double* max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getCurrentRanges(double* min, double* max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefCurrents(const double* currs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefCurrent(int m, double curr) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefCurrents(const int n_motor, const int* motors, const double* currs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefCurrents(double* currs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefCurrent(int m, double* curr) override;
 
     // IPidControl
 
-    bool setPid(const PidControlTypeEnum& pidtype, int j, const Pid& pid) override;
-    bool setPids(const PidControlTypeEnum& pidtype, const Pid* pids) override;
-    bool setPidReference(const PidControlTypeEnum& pidtype, int j, double ref) override;
-    bool setPidReferences(const PidControlTypeEnum& pidtype, const double* refs) override;
-    bool setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit) override;
-    bool setPidErrorLimits(const PidControlTypeEnum& pidtype, const double* limits) override;
-    bool getPidError(const PidControlTypeEnum& pidtype, int j, double* err) override;
-    bool getPidErrors(const PidControlTypeEnum& pidtype, double* errs) override;
-    bool getPidOutput(const PidControlTypeEnum& pidtype, int j, double* out) override;
-    bool getPidOutputs(const PidControlTypeEnum& pidtype, double* outs) override;
-    bool getPid(const PidControlTypeEnum& pidtype, int j, Pid* pid) override;
-    bool getPids(const PidControlTypeEnum& pidtype, Pid* pids) override;
-    bool getPidReference(const PidControlTypeEnum& pidtype, int j, double* ref) override;
-    bool getPidReferences(const PidControlTypeEnum& pidtype, double* refs) override;
-    bool getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double* limit) override;
-    bool getPidErrorLimits(const PidControlTypeEnum& pidtype, double* limits) override;
-    bool resetPid(const PidControlTypeEnum& pidtype, int j) override;
-    bool disablePid(const PidControlTypeEnum& pidtype, int j) override;
-    bool enablePid(const PidControlTypeEnum& pidtype, int j) override;
-    bool setPidOffset(const PidControlTypeEnum& pidtype, int j, double v) override;
-    bool isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPid(const PidControlTypeEnum& pidtype, int j, const Pid& pid) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPids(const PidControlTypeEnum& pidtype, const Pid* pids) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidReference(const PidControlTypeEnum& pidtype, int j, double ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidReferences(const PidControlTypeEnum& pidtype, const double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidErrorLimits(const PidControlTypeEnum& pidtype, const double* limits) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidError(const PidControlTypeEnum& pidtype, int j, double* err) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidErrors(const PidControlTypeEnum& pidtype, double* errs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidOutput(const PidControlTypeEnum& pidtype, int j, double* out) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidOutputs(const PidControlTypeEnum& pidtype, double* outs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPid(const PidControlTypeEnum& pidtype, int j, Pid* pid) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPids(const PidControlTypeEnum& pidtype, Pid* pids) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidReference(const PidControlTypeEnum& pidtype, int j, double* ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidReferences(const PidControlTypeEnum& pidtype, double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double* limit) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidErrorLimits(const PidControlTypeEnum& pidtype, double* limits) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 resetPid(const PidControlTypeEnum& pidtype, int j) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 disablePid(const PidControlTypeEnum& pidtype, int j) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 enablePid(const PidControlTypeEnum& pidtype, int j) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidOffset(const PidControlTypeEnum& pidtype, int j, double v) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidFeedforward(const PidControlTypeEnum& pidtype, int j, double v) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidOffset(const PidControlTypeEnum& pidtype, int j, double& v) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidFeedforward(const PidControlTypeEnum& pidtype, int j, double& v) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidExtraInfo(const PidControlTypeEnum& pidtype, int j, yarp::dev::PidExtraInfo& info) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidExtraInfos(const PidControlTypeEnum& pidtype, std::vector<yarp::dev::PidExtraInfo>& info) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool& enabled) override;
 
     // IControlBoardData
 

--- a/plugins/controlboard/include/ControlBoardDriver.hh
+++ b/plugins/controlboard/include/ControlBoardDriver.hh
@@ -92,8 +92,13 @@ public:
 
     // IControlLimits
 
+#if (YARP_VERSION_MAJOR > 3) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR > 12) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR == 12 && YARP_VERSION_PATCH >= 100)
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setPosLimits(int axis, double min, double max) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getPosLimits(int axis, double* min, double* max) override;
+#else
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setLimits(int axis, double min, double max) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getLimits(int axis, double* min, double* max) override;
+#endif
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setVelLimits(int axis, double min, double max) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getVelLimits(int axis, double* min, double* max) override;
 
@@ -135,6 +140,16 @@ public:
     YARP_DEV_RETURN_VALUE_TYPE_CH40 relativeMove(const double* deltas) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(int j, bool* flag) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(bool* flag) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop(int j) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop() override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 positionMove(const int n_joint, const int* joints, const double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 relativeMove(const int n_joint, const int* joints, const double* deltas) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(const int n_joint, const int* joints, bool* flag) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop(const int n_joint, const int* joints) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPosition(const int joint, double* ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPositions(double* refs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPositions(const int n_joint, const int* joints, double* refs) override;
+#if (YARP_VERSION_MAJOR > 3) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR > 12) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR == 12 && YARP_VERSION_PATCH >= 100)
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajSpeed(int j, double sp) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajSpeeds(const double* spds) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajAcceleration(int j, double acc) override;
@@ -143,28 +158,39 @@ public:
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajSpeeds(double* spds) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajAcceleration(int j, double* acc) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajAccelerations(double* accs) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop(int j) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop() override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 positionMove(const int n_joint, const int* joints, const double* refs) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 relativeMove(const int n_joint, const int* joints, const double* deltas) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 checkMotionDone(const int n_joint, const int* joints, bool* flag) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajSpeeds(const int n_joint, const int* joints, const double* spds) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setTrajAccelerations(const int n_joint, const int* joints, const double* accs) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajSpeeds(const int n_joint, const int* joints, double* spds) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTrajAccelerations(const int n_joint, const int* joints, double* accs) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 stop(const int n_joint, const int* joints) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPosition(const int joint, double* ref) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPositions(double* refs) override;
-    YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetPositions(const int n_joint, const int* joints, double* refs) override;
+#else
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefSpeed(int j, double sp) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefSpeeds(const double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefAcceleration(int j, double acc) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefAccelerations(const double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefSpeed(int j, double* ref) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefSpeeds(double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefAcceleration(int j, double* acc) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefAccelerations(double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefSpeeds(const int n_joint, const int* joints, const double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 setRefAccelerations(const int n_joint, const int* joints, const double* accs) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefSpeeds(const int n_joint, const int* joints, double* spds) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefAccelerations(const int n_joint, const int* joints, double* accs) override;
+#endif
 
     // IVelocityControl
 
     YARP_DEV_RETURN_VALUE_TYPE_CH40 velocityMove(int j, double sp) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 velocityMove(const double* sp) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 velocityMove(const int n_joint, const int* joints, const double* spds) override;
+#if (YARP_VERSION_MAJOR > 3) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR > 12) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR == 12 && YARP_VERSION_PATCH >= 100)
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetVelocity(const int joint, double* vel) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetVelocities(double* vels) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getTargetVelocities(const int n_joint, const int* joints, double* vels) override;
+#else
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefVelocity(const int joint, double* vel) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefVelocities(double* vels) override;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 getRefVelocities(const int n_joint, const int* joints, double* vels) override;
+#endif
 
     // ICurrentControl
 
@@ -201,12 +227,16 @@ public:
     YARP_DEV_RETURN_VALUE_TYPE_CH40 disablePid(const PidControlTypeEnum& pidtype, int j) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 enablePid(const PidControlTypeEnum& pidtype, int j) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidOffset(const PidControlTypeEnum& pidtype, int j, double v) override;
+#if (YARP_VERSION_MAJOR > 3) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR > 12) || (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR == 12 && YARP_VERSION_PATCH >= 100)
     YARP_DEV_RETURN_VALUE_TYPE_CH40 setPidFeedforward(const PidControlTypeEnum& pidtype, int j, double v) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidOffset(const PidControlTypeEnum& pidtype, int j, double& v) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidFeedforward(const PidControlTypeEnum& pidtype, int j, double& v) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidExtraInfo(const PidControlTypeEnum& pidtype, int j, yarp::dev::PidExtraInfo& info) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 getPidExtraInfos(const PidControlTypeEnum& pidtype, std::vector<yarp::dev::PidExtraInfo>& info) override;
     YARP_DEV_RETURN_VALUE_TYPE_CH40 isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool& enabled) override;
+#else
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled) override;
+#endif
 
     // IControlBoardData
 

--- a/plugins/controlboard/src/ControlBoard.cpp
+++ b/plugins/controlboard/src/ControlBoard.cpp
@@ -532,7 +532,7 @@ bool ControlBoard::updateReferences(const UpdateInfo& _info, EntityComponentMana
             forceReference = joint.commonJointProperties.refTorque;
             break;
         case VOCAB_CM_VELOCITY: {
-            auto& pid = joint.pidControllers[yarp::dev::VOCAB_PIDTYPE_VELOCITY];
+            auto& pid = joint.pidControllers[yarp::dev::PidControlTypeEnum::VOCAB_PIDTYPE_VELOCITY];
             forceReference
                 = pid.Update(ControlBoardData::convertUserToGazebo(joint, joint.commonJointProperties.velocity)
                              - ControlBoardData::convertUserToGazebo(joint, joint.commonJointProperties.refVelocity),
@@ -542,7 +542,7 @@ bool ControlBoard::updateReferences(const UpdateInfo& _info, EntityComponentMana
         case VOCAB_CM_POSITION:
         case VOCAB_CM_POSITION_DIRECT: {
             // TODO manage motor positions instead of joint positions when implemented
-            auto& pid = joint.pidControllers[yarp::dev::VOCAB_PIDTYPE_POSITION];
+            auto& pid = joint.pidControllers[yarp::dev::PidControlTypeEnum::VOCAB_PIDTYPE_POSITION];
             forceReference = pid.Update(ControlBoardData::convertUserToGazebo(joint, joint.commonJointProperties.position)
                                             - ControlBoardData::convertUserToGazebo(joint, joint.commonJointProperties.refPosition),
                                         _info.dt);

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -46,403 +46,403 @@ bool ControlBoardDriver::close()
 
 // IInteractionMode
 
-bool ControlBoardDriver::getInteractionMode(int axis, yarp::dev::InteractionModeEnum* mode)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getInteractionMode(int axis, yarp::dev::InteractionModeEnum* mode)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     *mode = m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.interactionMode;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getInteractionModes(int n_joints,
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getInteractionModes(int n_joints,
                                              int* joints,
                                              yarp::dev::InteractionModeEnum* modes)
 {
     if (!joints)
     {
         yError() << "Error while getting interaction modes: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!modes)
     {
         yError() << "Error while getting interaction modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joints; i++)
     {
         if (!ControlBoardDriver::getInteractionMode(joints[i], &modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getInteractionModes(yarp::dev::InteractionModeEnum* modes)
 {
     if (!modes)
     {
         yError() << "Error while getting interaction modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getInteractionMode(i, &modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setInteractionMode(int axis, yarp::dev::InteractionModeEnum mode)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
-    return m_controlBoardData->setInteractionMode(axis, mode);
+    return m_controlBoardData->setInteractionMode(axis, mode) ? YARP_DEV_RETURN_VALUE_OK_CH40 : YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
 }
 
-bool ControlBoardDriver::setInteractionModes(int n_joints,
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setInteractionModes(int n_joints,
                                              int* joints,
                                              yarp::dev::InteractionModeEnum* modes)
 {
     if (!joints)
     {
         yError() << "Error while setting interaction modes: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!modes)
     {
         yError() << "Error while setting interaction modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joints; i++)
     {
         if (!ControlBoardDriver::setInteractionMode(joints[i], modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setInteractionModes(yarp::dev::InteractionModeEnum* modes)
 {
     if (!modes)
     {
         yError() << "Error while setting interaction modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::setInteractionMode(i, modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IControlMode
 
-bool ControlBoardDriver::getControlMode(int j, int* mode)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getControlMode(int j, int* mode)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!mode)
     {
         yError() << "Error while getting control mode: mode array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting control mode: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *mode = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.controlMode;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getControlModes(int* modes)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getControlModes(int* modes)
 {
     if (!modes)
     {
         yError() << "Error while getting control modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getControlMode(i, &modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getControlModes(const int n_joint, const int* joints, int* modes)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getControlModes(const int n_joint, const int* joints, int* modes)
 {
     if (!joints)
     {
         yError() << "Error while getting control modes: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!modes)
     {
         yError() << "Error while getting control modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::getControlMode(joints[i], &modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setControlMode(const int j, const int mode)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setControlMode(const int j, const int mode)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
-    return m_controlBoardData->setControlMode(j, mode);
+    return m_controlBoardData->setControlMode(j, mode) ? YARP_DEV_RETURN_VALUE_OK_CH40 : YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
 }
 
-bool ControlBoardDriver::setControlModes(const int n_joint, const int* joints, int* modes)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setControlModes(const int n_joint, const int* joints, int* modes)
 {
     if (!joints)
     {
         yError() << "Error while setting control modes: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!modes)
     {
         yError() << "Error while setting control modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::setControlMode(joints[i], modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setControlModes(int* modes)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setControlModes(int* modes)
 {
     if (!modes)
     {
         yError() << "Error while setting control modes: modes array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::setControlMode(i, modes[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IAxisInfo
 
-bool ControlBoardDriver::getAxisName(int axis, std::string& name)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getAxisName(int axis, std::string& name)
 {
     // TODO integrate with IJointCoupled interface
 
     name = m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.name;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getJointType(int axis, yarp::dev::JointTypeEnum& type)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getJointType(int axis, yarp::dev::JointTypeEnum& type)
 {
     // TODO integrate with IJointCoupled interface
 
     type = yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_REVOLUTE;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IControlLimits
 
-bool ControlBoardDriver::setLimits(int axis, double min, double max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPosLimits(int axis, double min, double max)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (axis < 0 || axis >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while setting limits: axis index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.positionLimitMin = min;
     m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.positionLimitMax = max;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getLimits(int axis, double* min, double* max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPosLimits(int axis, double* min, double* max)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!min)
     {
         yError() << "Error while getting limits: min is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!max)
     {
         yError() << "Error while getting limits: max is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (axis < 0 || axis >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting limits: axis index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *min = m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.positionLimitMin;
     *max = m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.positionLimitMax;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setVelLimits(int axis, double min, double max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setVelLimits(int axis, double min, double max)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (axis < 0 || axis >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while setting velocity limits: axis index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.velocityLimitMin = min;
     m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.velocityLimitMax = max;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getVelLimits(int axis, double* min, double* max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getVelLimits(int axis, double* min, double* max)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!min)
     {
         yError() << "Error while getting velocity limits: min is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!max)
     {
         yError() << "Error while getting velocity limits: max is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (axis < 0 || axis >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting velocity limits: axis index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *min = m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.velocityLimitMin;
     *max = m_controlBoardData->actuatedAxes.at(axis).commonJointProperties.velocityLimitMax;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IRemoteVariables
 
-bool ControlBoardDriver::getRemoteVariable(std::string key, yarp::os::Bottle& val)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRemoteVariable(std::string key, yarp::os::Bottle& val)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setRemoteVariable(std::string key, const yarp::os::Bottle& val)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRemoteVariable(std::string key, const yarp::os::Bottle& val)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getRemoteVariablesList(yarp::os::Bottle* listOfKeys)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRemoteVariablesList(yarp::os::Bottle* listOfKeys)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
 
 // ITorqueControl
 
-bool ControlBoardDriver::getAxes(int* ax)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getAxes(int* ax)
 {
     // TODO integrate with IJointCoupled interface
 
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
     *ax = m_controlBoardData->actuatedAxes.size();
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefTorque(int j, double* t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefTorque(int j, double* t)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!t)
     {
         yError() << "Error while getting reference torque: t is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting reference torque: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *t = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.refTorque;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefTorques(double* t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefTorques(double* t)
 {
     if (!t)
     {
         yError() << "Error while getting reference torques: t array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getRefTorque(i, &t[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefTorque(int j, double t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefTorque(int j, double t)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -450,59 +450,59 @@ bool ControlBoardDriver::setRefTorque(int j, double t)
     {
         yError() << "Error while setting reference torque: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!ControlBoardDriver::checkRefTorqueIsValid(t))
     {
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(j).commonJointProperties.refTorque = t;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefTorques(const double* t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefTorques(const double* t)
 {
     if (!t)
     {
         yError() << "Error while setting reference torques: t array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::setRefTorque(i, t[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefTorques(const int n_joint, const int* joints, const double* t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefTorques(const int n_joint, const int* joints, const double* t)
 {
     if (!joints)
     {
         yError() << "Error while setting reference torques: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!t)
     {
         yError() << "Error while setting reference torques: t array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::setRefTorque(joints[i], t[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 bool ControlBoardDriver::checkRefTorqueIsValid(double refTorque)
@@ -516,114 +516,114 @@ bool ControlBoardDriver::checkRefTorqueIsValid(double refTorque)
     return true;
 }
 
-bool ControlBoardDriver::getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getMotorTorqueParams(int j, yarp::dev::MotorTorqueParameters* params)
 {
     // TODO
 
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
 
-bool ControlBoardDriver::setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params)
 {
     // TODO
 
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
 
-bool ControlBoardDriver::getTorque(int j, double* t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTorque(int j, double* t)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!t)
     {
         yError() << "Error while getting torque: t is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting torque: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *t = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.torque;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getTorques(double* t)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTorques(double* t)
 {
     if (!t)
     {
         yError() << "Error while getting torques: t array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getTorque(i, &t[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getTorqueRange(int j, double* min, double* max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTorqueRange(int j, double* min, double* max)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!min)
     {
         yError() << "Error while getting torque range: min is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!max)
     {
         yError() << "Error while getting torque range: max is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting torque range: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *min = -m_controlBoardData->actuatedAxes.at(j).commonJointProperties.maxTorqueAbs;
     *max = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.maxTorqueAbs;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getTorqueRanges(double* min, double* max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTorqueRanges(double* min, double* max)
 {
     if (!min)
     {
         yError() << "Error while getting torque ranges: min array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!max)
     {
         yError() << "Error while getting torque ranges: max array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getTorqueRange(i, &min[i], &max[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IPositionDirect
 
-bool ControlBoardDriver::setPosition(int j, double ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPosition(int j, double ref)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -631,124 +631,124 @@ bool ControlBoardDriver::setPosition(int j, double ref)
     {
         yError() << "Error while setting position: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     if (m_controlBoardData->actuatedAxes.at(j).commonJointProperties.controlMode != VOCAB_CM_POSITION_DIRECT)
     {
         yError() << "Error while setting position: joint " + std::to_string(j)
                         + " is not in position direct mode";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(j).commonJointProperties.refPosition = ref;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setPositions(const int n_joint, const int* joints, const double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPositions(const int n_joint, const int* joints, const double* refs)
 {
     if (!joints)
     {
         yError() << "Error while setting positions: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!refs)
     {
         yError() << "Error while setting positions: refs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::setPosition(joints[i], refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setPositions(const double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPositions(const double* refs)
 {
     if (!refs)
     {
         yError("Error while setting positions: refs array is null");
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::setPosition(i, refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefPosition(const int joint, double* ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefPosition(const int joint, double* ref)
 {
     if (joint < 0 || joint >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting reference position: joint index " + std::to_string(joint)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *ref = m_controlBoardData->actuatedAxes.at(joint).commonJointProperties.refPosition;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefPositions(double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefPositions(double* refs)
 {
     if (!refs)
     {
         yError() << "Error while getting reference positions: refs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getRefPosition(i, &refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefPositions(const int n_joint, const int* joints, double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefPositions(const int n_joint, const int* joints, double* refs)
 {
     if (!joints)
     {
         yError() << "Error while getting reference positions: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!refs)
     {
         yError() << "Error while getting reference positions: refs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::getRefPosition(joints[i], &refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IPositionControl
 
-bool ControlBoardDriver::positionMove(int j, double ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::positionMove(int j, double ref)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -756,7 +756,7 @@ bool ControlBoardDriver::positionMove(int j, double ref)
     {
         yError() << "Error while setting reference position for trajectory generation: joint index "
                         + std::to_string(j) + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     auto& joint = m_controlBoardData->actuatedAxes.at(j);
@@ -775,233 +775,233 @@ bool ControlBoardDriver::positionMove(int j, double ref)
                                               joint.trajectoryGenerationRefAcceleration,
                                               m_controlBoardData->controlUpdatePeriod);
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::positionMove(const double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::positionMove(const double* refs)
 {
     if (!refs)
     {
         yError() << "Error while setting reference positions for trajectory generation: refs array "
                     "is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::positionMove(i, refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::relativeMove(int j, double delta)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::relativeMove(int j, double delta)
 {
     // Check on valid joint number done in setPosition
     return setPosition(j, m_controlBoardData->actuatedAxes.at(j).commonJointProperties.position + delta);
 }
 
-bool ControlBoardDriver::relativeMove(const double* deltas)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::relativeMove(const double* deltas)
 {
     if (!deltas)
     {
         yError() << "Error while setting relative positions: deltas array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::relativeMove(i, deltas[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::checkMotionDone(int j, bool* flag)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::checkMotionDone(int j, bool* flag)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while checking motion done: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *flag = m_controlBoardData->actuatedAxes.at(j).isMotionDone;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::checkMotionDone(bool* flag)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::checkMotionDone(bool* flag)
 {
     if (!flag)
     {
         yError() << "Error while checking motion done: flag is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::checkMotionDone(i, &flag[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 
-bool ControlBoardDriver::setRefSpeed(int j, double sp)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeed(int j, double sp)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while setting reference speed: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(j).trajectoryGenerationRefSpeed = sp;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefSpeeds(const double* spds)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const double* spds)
 {
     if (!spds)
     {
         yError() << "Error while setting reference speeds: spds array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
-        if (!ControlBoardDriver::setRefSpeed(i, spds[i]))
+        if (!ControlBoardDriver::setTrajSpeed(i, spds[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefAcceleration(int j, double acc)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAcceleration(int j, double acc)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while setting reference acceleration: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(j).trajectoryGenerationRefAcceleration = acc;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefAccelerations(const double* accs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const double* accs)
 {
     if (!accs)
     {
         yError() << "Error while setting reference accelerations: accs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
-        if (!ControlBoardDriver::setRefAcceleration(i, accs[i]))
+        if (!ControlBoardDriver::setTrajAcceleration(i, accs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefSpeed(int j, double* ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeed(int j, double* ref)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting reference speed: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *ref = m_controlBoardData->actuatedAxes.at(j).trajectoryGenerationRefSpeed;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefSpeeds(double* spds)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(double* spds)
 {
     if (!spds)
     {
         yError() << "Error while getting reference speeds: spds array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
-        if (!ControlBoardDriver::getRefSpeed(i, &spds[i]))
+        if (!ControlBoardDriver::getTrajSpeed(i, &spds[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefAcceleration(int j, double* acc)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAcceleration(int j, double* acc)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting reference acceleration: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *acc = m_controlBoardData->actuatedAxes.at(j).trajectoryGenerationRefAcceleration;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefAccelerations(double* accs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAccelerations(double* accs)
 {
     if (!accs)
     {
         yError() << "Error while getting reference accelerations: accs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
-        if (!ControlBoardDriver::getRefAcceleration(i, &accs[i]))
+        if (!ControlBoardDriver::getTrajAcceleration(i, &accs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::stop(int j)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::stop(int j)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while stopping: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     switch (m_controlBoardData->actuatedAxes.at(j).commonJointProperties.controlMode)
@@ -1027,211 +1027,211 @@ bool ControlBoardDriver::stop(int j)
         break;
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::stop()
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::stop()
 {
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::stop(i))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::positionMove(const int n_joint, const int* joints, const double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::positionMove(const int n_joint, const int* joints, const double* refs)
 {
     if (!joints)
     {
         yError() << "Error while setting reference positions for trajectory generation: joints "
                     "array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!refs)
     {
         yError() << "Error while setting reference positions for trajectory generation: refs array "
                     "is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::positionMove(joints[i], refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::relativeMove(const int n_joint, const int* joints, const double* deltas)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::relativeMove(const int n_joint, const int* joints, const double* deltas)
 {
     if (!joints)
     {
         yError() << "Error while setting relative positions: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!deltas)
     {
         yError() << "Error while setting relative positions: deltas array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::relativeMove(joints[i], deltas[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-bool ControlBoardDriver::checkMotionDone(const int n_joint, const int* joints, bool* flag)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::checkMotionDone(const int n_joint, const int* joints, bool* flag)
 {
     if (!joints)
     {
         yError() << "Error while checking motion done: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!flag)
     {
         yError() << "Error while checking motion done: flag array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::checkMotionDone(joints[i], &flag[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setRefSpeeds(const int n_joint, const int* joints, const double* spds)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const int n_joint, const int* joints, const double* spds)
 {
     if (!joints)
     {
         yError() << "Error while setting reference speeds: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!spds)
     {
         yError() << "Error while setting reference speeds: spds array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
-        if (!ControlBoardDriver::setRefSpeed(joints[i], spds[i]))
+        if (!ControlBoardDriver::setTrajSpeed(joints[i], spds[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-bool ControlBoardDriver::setRefAccelerations(const int n_joint,
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const int n_joint,
                                              const int* joints,
                                              const double* accs)
 {
     if (!joints)
     {
         yError() << "Error while setting reference accelerations: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!accs)
     {
         yError() << "Error while setting reference accelerations: accs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
-        if (!ControlBoardDriver::setRefAcceleration(joints[i], accs[i]))
+        if (!ControlBoardDriver::setTrajAcceleration(joints[i], accs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefSpeeds(const int n_joint, const int* joints, double* spds)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(const int n_joint, const int* joints, double* spds)
 {
     if (!joints)
     {
         yError() << "Error while getting reference speeds: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!spds)
     {
         yError() << "Error while getting reference speeds: spds array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
-        if (!ControlBoardDriver::getRefSpeed(joints[i], &spds[i]))
+        if (!ControlBoardDriver::getTrajSpeed(joints[i], &spds[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getRefAccelerations(const int n_joint, const int* joints, double* accs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAccelerations(const int n_joint, const int* joints, double* accs)
 {
     if (!joints)
     {
         yError() << "Error while getting reference accelerations: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!accs)
     {
         yError() << "Error while getting reference accelerations: accs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
-        if (!ControlBoardDriver::getRefAcceleration(joints[i], &accs[i]))
+        if (!ControlBoardDriver::getTrajAcceleration(joints[i], &accs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-bool ControlBoardDriver::stop(const int n_joint, const int* joints)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::stop(const int n_joint, const int* joints)
 {
     if (!joints)
     {
         yError() << "Error while stopping: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::stop(joints[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getTargetPosition(const int joint, double* ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetPosition(const int joint, double* ref)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -1239,60 +1239,60 @@ bool ControlBoardDriver::getTargetPosition(const int joint, double* ref)
     {
         yError() << "Error while getting target position: joint index " + std::to_string(joint)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *ref = m_controlBoardData->actuatedAxes.at(joint).trajectoryGenerationRefPosition;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getTargetPositions(double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetPositions(double* refs)
 {
     if (!refs)
     {
         yError() << "Error while getting target positions: refs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getTargetPosition(i, &refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getTargetPositions(const int n_joint, const int* joints, double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetPositions(const int n_joint, const int* joints, double* refs)
 {
     if (!joints)
     {
         yError() << "Error while getting target positions: joints array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!refs)
     {
         yError() << "Error while getting target positions: refs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < n_joint; i++)
     {
         if (!ControlBoardDriver::getTargetPosition(joints[i], &refs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IVelocityControl
 
-bool ControlBoardDriver::velocityMove(int j, double sp)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::velocityMove(int j, double sp)
 {
     size_t numberOfJoints = m_controlBoardData->actuatedAxes.size();
     if (j >= 0 && static_cast<size_t>(j) < numberOfJoints)
@@ -1304,122 +1304,122 @@ bool ControlBoardDriver::velocityMove(int j, double sp)
             double refvel = sp;
             m_controlBoardData->actuatedAxes[j].speedRampHandler->setReference(refvel, refacc);
         }
-        return true;
+        return YARP_DEV_RETURN_VALUE_OK_CH40;
     }
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
 }
-bool ControlBoardDriver::velocityMove(const double* sp)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::velocityMove(const double* sp)
 {
-    if (!sp) {return false;}
+    if (!sp) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
 
     size_t numberOfJoints = m_controlBoardData->actuatedAxes.size();
     for (size_t i = 0; i < numberOfJoints; ++i)
     {
         velocityMove(i, sp[i]);
     }
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-bool ControlBoardDriver::velocityMove(const int n_joint, const int* joints, const double* spds)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::velocityMove(const int n_joint, const int* joints, const double* spds)
 {
-    if (!joints || !spds) {return false;}
+    if (!joints || !spds) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
 
-    bool ret = true;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
     for (int i = 0; i < n_joint && ret; i++)
     {
         ret = velocityMove(joints[i], spds[i]);
     }
     return ret;
 }
-bool ControlBoardDriver::getRefVelocity(const int joint, double* vel)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocity(const int joint, double* vel)
 {
     size_t numberOfJoints = m_controlBoardData->actuatedAxes.size();
     if (vel && joint >= 0 && static_cast<size_t>(joint) < numberOfJoints)
     {
         *vel = m_controlBoardData->actuatedAxes[joint].commonJointProperties.refVelocity;
-        return true;
+        return YARP_DEV_RETURN_VALUE_OK_CH40;
     }
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
 }
-bool ControlBoardDriver::getRefVelocities(double* vels)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocities(double* vels)
 {
-    if (!vels) {return false;}
+    if (!vels) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
 
     size_t numberOfJoints = m_controlBoardData->actuatedAxes.size();
-    bool ret = true;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
     for (size_t i = 0; i < numberOfJoints && ret; i++)
     {
-        ret = getRefVelocity(i, &vels[i]);
+        ret = getTargetVelocity(i, &vels[i]);
     }
     return ret;
 }
-bool ControlBoardDriver::getRefVelocities(const int n_joint, const int* joints, double* vels)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocities(const int n_joint, const int* joints, double* vels)
 {
-    if (!joints || !vels) {return false;}
+    if (!joints || !vels) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
 
-    bool ret = true;
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
     for (int i = 0; i < n_joint && ret; i++)
     {
-        ret = getRefVelocity(joints[i], &vels[i]);
+        ret = getTargetVelocity(joints[i], &vels[i]);
     }
     return ret;
 }
 
 // ICurrentControl
 
-bool ControlBoardDriver::getNumberOfMotors(int* ax)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getNumberOfMotors(int* ax)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getCurrent(int m, double* curr)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getCurrent(int m, double* curr)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getCurrents(double* currs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getCurrents(double* currs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getCurrentRange(int m, double* min, double* max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getCurrentRange(int m, double* min, double* max)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getCurrentRanges(double* min, double* max)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getCurrentRanges(double* min, double* max)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setRefCurrents(const double* currs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefCurrents(const double* currs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setRefCurrent(int m, double curr)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefCurrent(int m, double curr)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setRefCurrents(const int n_motor, const int* motors, const double* currs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefCurrents(const int n_motor, const int* motors, const double* currs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getRefCurrents(double* currs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefCurrents(double* currs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getRefCurrent(int m, double* curr)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefCurrent(int m, double* curr)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
 
 // IPidControl
 
-bool ControlBoardDriver::setPid(const PidControlTypeEnum& pidtype, int j, const Pid& pid)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPid(const PidControlTypeEnum& pidtype, int j, const Pid& pid)
 {
     gz::math::PID& gzpid = m_controlBoardData->physicalJoints[j].pidControllers[pidtype];
     gzpid.SetPGain(pid.kp);
@@ -1435,13 +1435,13 @@ bool ControlBoardDriver::setPid(const PidControlTypeEnum& pidtype, int j, const 
     gzpid.SetCmdMax(pid.max_output);
     gzpid.SetCmdMin(-pid.max_output);
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-bool ControlBoardDriver::setPids(const PidControlTypeEnum& pidtype, const Pid* pids)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPids(const PidControlTypeEnum& pidtype, const Pid* pids)
 {
     size_t i = 0;
-    bool ret = true;
-    if (!pids) {return false;}
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
+    if (!pids) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
     for (auto it = m_controlBoardData->physicalJoints.begin();
         it != m_controlBoardData->physicalJoints.end();
         it++)
@@ -1450,49 +1450,49 @@ bool ControlBoardDriver::setPids(const PidControlTypeEnum& pidtype, const Pid* p
     }
     return ret;
 }
-bool ControlBoardDriver::setPidReference(const PidControlTypeEnum& pidtype, int j, double ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidReference(const PidControlTypeEnum& pidtype, int j, double ref)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setPidReferences(const PidControlTypeEnum& pidtype, const double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidReferences(const PidControlTypeEnum& pidtype, const double* refs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double limit)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setPidErrorLimits(const PidControlTypeEnum& pidtype, const double* limits)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidErrorLimits(const PidControlTypeEnum& pidtype, const double* limits)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidError(const PidControlTypeEnum& pidtype, int j, double* err)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidError(const PidControlTypeEnum& pidtype, int j, double* err)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidErrors(const PidControlTypeEnum& pidtype, double* errs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidErrors(const PidControlTypeEnum& pidtype, double* errs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidOutput(const PidControlTypeEnum& pidtype, int j, double* out)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidOutput(const PidControlTypeEnum& pidtype, int j, double* out)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidOutputs(const PidControlTypeEnum& pidtype, double* outs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidOutputs(const PidControlTypeEnum& pidtype, double* outs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPid(const PidControlTypeEnum& pidtype, int j, Pid* pid)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPid(const PidControlTypeEnum& pidtype, int j, Pid* pid)
 {
-    if (!pid) {return false;}
+    if (!pid) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
     gz::math::PID gzpid = m_controlBoardData->physicalJoints[j].pidControllers[pidtype];
 
     pid->scale = 0;
@@ -1502,13 +1502,13 @@ bool ControlBoardDriver::getPid(const PidControlTypeEnum& pidtype, int j, Pid* p
     pid->max_int = gzpid.IMax();
     pid->max_output = gzpid.CmdMax();
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-bool ControlBoardDriver::getPids(const PidControlTypeEnum& pidtype, Pid* pids)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPids(const PidControlTypeEnum& pidtype, Pid* pids)
 {
     size_t i = 0;
-    bool ret = true;
-    if (!pids) {return false;}
+    YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
+    if (!pids) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
     for (auto it = m_controlBoardData->physicalJoints.begin();
         it != m_controlBoardData->physicalJoints.end();
         it++)
@@ -1518,50 +1518,81 @@ bool ControlBoardDriver::getPids(const PidControlTypeEnum& pidtype, Pid* pids)
     }
     return ret;
 }
-bool ControlBoardDriver::getPidReference(const PidControlTypeEnum& pidtype, int j, double* ref)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidReference(const PidControlTypeEnum& pidtype, int j, double* ref)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidReferences(const PidControlTypeEnum& pidtype, double* refs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidReferences(const PidControlTypeEnum& pidtype, double* refs)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double* limit)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidErrorLimit(const PidControlTypeEnum& pidtype, int j, double* limit)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::getPidErrorLimits(const PidControlTypeEnum& pidtype, double* limits)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidErrorLimits(const PidControlTypeEnum& pidtype, double* limits)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::resetPid(const PidControlTypeEnum& pidtype, int j)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::resetPid(const PidControlTypeEnum& pidtype, int j)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::disablePid(const PidControlTypeEnum& pidtype, int j)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::disablePid(const PidControlTypeEnum& pidtype, int j)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::enablePid(const PidControlTypeEnum& pidtype, int j)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::enablePid(const PidControlTypeEnum& pidtype, int j)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::setPidOffset(const PidControlTypeEnum& pidtype, int j, double v)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidOffset(const PidControlTypeEnum& pidtype, int j, double v)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-bool ControlBoardDriver::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled)
+
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidFeedforward(const PidControlTypeEnum& pidtype, int j, double v)
 {
     // TODO
-    return true;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
+}
+
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidOffset(const PidControlTypeEnum& pidtype, int j, double& v)
+{
+    // TODO
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
+}
+
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidFeedforward(const PidControlTypeEnum& pidtype, int j, double& v)
+{
+    // TODO
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
+}
+
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidExtraInfo(const PidControlTypeEnum& pidtype, int j, yarp::dev::PidExtraInfo& info)
+{
+    // TODO
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
+}
+
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidExtraInfos(const PidControlTypeEnum& pidtype, std::vector<yarp::dev::PidExtraInfo>& info)
+{
+    // TODO
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
+}
+
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool& enabled)
+{
+    // TODO
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
 
 // IEncodersTimed
@@ -1572,35 +1603,35 @@ bool ControlBoardDriver::isPidEnabled(const PidControlTypeEnum& pidtype, int j, 
  * Since we don't know how to reset gazebo encoders, we will simply add the actual value to the
  * future encoders readings
  */
-bool ControlBoardDriver::resetEncoder(int j)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::resetEncoder(int j)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while resetting encoder: joint index out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(j).commonJointProperties.zeroPosition = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.position;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::resetEncoders()
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::resetEncoders()
 {
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::resetEncoder(i))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setEncoder(int j, double val)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setEncoder(int j, double val)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -1608,205 +1639,205 @@ bool ControlBoardDriver::setEncoder(int j, double val)
     {
         yError() << "Error while setting encoder: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     m_controlBoardData->actuatedAxes.at(j).commonJointProperties.zeroPosition = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.position - val;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::setEncoders(const double* vals)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setEncoders(const double* vals)
 {
     if (!vals)
     {
         yError() << "Error while setting encoders: vals array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::setEncoder(i, vals[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoder(int j, double* v)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoder(int j, double* v)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!v)
     {
         yError() << "Error while getting encoder: v is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting encoder: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *v = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.position - m_controlBoardData->actuatedAxes.at(j).commonJointProperties.zeroPosition;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoders(double* encs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoders(double* encs)
 {
     if (!encs)
     {
         yError() << "Error while getting encoders: encs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getEncoder(i, &encs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoderSpeed(int j, double* sp)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoderSpeed(int j, double* sp)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!sp)
     {
         yError() << "Error while getting encoder speed: sp is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting encoder speed: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *sp = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.velocity;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoderSpeeds(double* spds)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoderSpeeds(double* spds)
 {
     if (!spds)
     {
         yError() << "Error while getting encoder speeds: spds array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getEncoderSpeed(i, &spds[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoderAcceleration(int j, double* acc)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoderAcceleration(int j, double* acc)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!acc)
     {
         yError() << "Error while getting encoder acceleration: acc is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting encoder acceleration: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *acc = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.acceleration;
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoderAccelerations(double* accs)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoderAccelerations(double* accs)
 {
     if (!accs)
     {
         yError() << "Error while getting encoder accelerations: accs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getEncoderAcceleration(i, &accs[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncoderTimed(int j, double* encs, double* time)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncoderTimed(int j, double* encs, double* time)
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
     if (!encs)
     {
         yError() << "Error while getting encoder: encs is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!time)
     {
         yError() << "Error while getting encoder: time is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (j < 0 || j >= m_controlBoardData->actuatedAxes.size())
     {
         yError() << "Error while getting encoder: joint index " + std::to_string(j)
                         + " out of range";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     *encs
         = m_controlBoardData->actuatedAxes.at(j).commonJointProperties.position - m_controlBoardData->actuatedAxes.at(j).commonJointProperties.zeroPosition;
     *time = m_controlBoardData->simTime.getTime();
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-bool ControlBoardDriver::getEncodersTimed(double* encs, double* time)
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getEncodersTimed(double* encs, double* time)
 {
     if (!encs)
     {
         yError() << "Error while getting encoders: encs array is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
     if (!time)
     {
         yError() << "Error while getting encoders: time is null";
-        return false;
+        return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
     }
 
     for (int i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
         if (!ControlBoardDriver::getEncoderTimed(i, &encs[i], &time[i]))
         {
-            return false;
+            return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
     }
 
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
 // IControlBoardData

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -288,8 +288,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getJointType(int axis, yarp:
 }
 
 // IControlLimits
-
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPosLimits(int axis, double min, double max)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setLimits(int axis, double min, double max)
+#endif
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -304,8 +307,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPosLimits(int axis, doubl
 
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPosLimits(int axis, double* min, double* max)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getLimits(int axis, double* min, double* max)
+#endif
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -857,8 +863,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::checkMotionDone(bool* flag)
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
-
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeed(int j, double sp)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefSpeed(int j, double sp)
+#endif
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -872,8 +881,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeed(int j, double s
 
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const double* spds)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefSpeeds(const double* spds)
+#endif
 {
     if (!spds)
     {
@@ -883,7 +895,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const double* 
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::setTrajSpeed(i, spds[i]))
+#else
+        if (!ControlBoardDriver::setRefSpeed(i, spds[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -891,8 +907,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const double* 
 
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
-
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAcceleration(int j, double acc)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefAcceleration(int j, double acc)
+#endif
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -907,7 +926,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAcceleration(int j, d
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const double* accs)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefAccelerations(const double* accs)
+#endif
 {
     if (!accs)
     {
@@ -917,7 +940,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const d
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::setTrajAcceleration(i, accs[i]))
+#else
+        if (!ControlBoardDriver::setRefAcceleration(i, accs[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -926,7 +953,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const d
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeed(int j, double* ref)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefSpeed(int j, double* ref)
+#endif
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -941,7 +972,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeed(int j, double* 
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(double* spds)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefSpeeds(double* spds)
+#endif
 {
     if (!spds)
     {
@@ -951,7 +986,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(double* spds)
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::getTrajSpeed(i, &spds[i]))
+#else
+        if (!ControlBoardDriver::getRefSpeed(i, &spds[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -960,7 +999,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(double* spds)
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAcceleration(int j, double* acc)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefAcceleration(int j, double* acc)
+#endif
 {
     std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
@@ -975,7 +1018,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAcceleration(int j, d
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAccelerations(double* accs)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefAccelerations(double* accs)
+#endif
 {
     if (!accs)
     {
@@ -985,7 +1032,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAccelerations(double*
 
     for (size_t i = 0; i < m_controlBoardData->actuatedAxes.size(); i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::getTrajAcceleration(i, &accs[i]))
+#else
+        if (!ControlBoardDriver::getRefAcceleration(i, &accs[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -1116,7 +1167,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::checkMotionDone(const int n_
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const int n_joint, const int* joints, const double* spds)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefSpeeds(const int n_joint, const int* joints, const double* spds)
+#endif
 {
     if (!joints)
     {
@@ -1131,7 +1186,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const int n_jo
 
     for (int i = 0; i < n_joint; i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::setTrajSpeed(joints[i], spds[i]))
+#else
+        if (!ControlBoardDriver::setRefSpeed(joints[i], spds[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -1139,9 +1198,15 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajSpeeds(const int n_jo
 
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const int n_joint,
                                              const int* joints,
                                              const double* accs)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setRefAccelerations(const int n_joint,
+                                             const int* joints,
+                                             const double* accs)
+#endif
 {
     if (!joints)
     {
@@ -1156,7 +1221,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const i
 
     for (int i = 0; i < n_joint; i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::setTrajAcceleration(joints[i], accs[i]))
+#else
+        if (!ControlBoardDriver::setRefAcceleration(joints[i], accs[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -1165,7 +1234,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setTrajAccelerations(const i
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(const int n_joint, const int* joints, double* spds)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefSpeeds(const int n_joint, const int* joints, double* spds)
+#endif
 {
     if (!joints)
     {
@@ -1180,7 +1253,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(const int n_jo
 
     for (int i = 0; i < n_joint; i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::getTrajSpeed(joints[i], &spds[i]))
+#else
+        if (!ControlBoardDriver::getRefSpeed(joints[i], &spds[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -1189,7 +1266,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajSpeeds(const int n_jo
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAccelerations(const int n_joint, const int* joints, double* accs)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefAccelerations(const int n_joint, const int* joints, double* accs)
+#endif
 {
     if (!joints)
     {
@@ -1204,7 +1285,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTrajAccelerations(const i
 
     for (int i = 0; i < n_joint; i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         if (!ControlBoardDriver::getTrajAcceleration(joints[i], &accs[i]))
+#else
+        if (!ControlBoardDriver::getRefAcceleration(joints[i], &accs[i]))
+#endif
         {
             return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
         }
@@ -1330,7 +1415,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::velocityMove(const int n_joi
     }
     return ret;
 }
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocity(const int joint, double* vel)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefVelocity(const int joint, double* vel)
+#endif
 {
     size_t numberOfJoints = m_controlBoardData->actuatedAxes.size();
     if (vel && joint >= 0 && static_cast<size_t>(joint) < numberOfJoints)
@@ -1340,7 +1429,11 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocity(const int 
     }
     return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;
 }
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocities(double* vels)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefVelocities(double* vels)
+#endif
 {
     if (!vels) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
 
@@ -1348,18 +1441,30 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocities(double* 
     YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
     for (size_t i = 0; i < numberOfJoints && ret; i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         ret = getTargetVelocity(i, &vels[i]);
+#else
+        ret = getRefVelocity(i, &vels[i]);
+#endif
     }
     return ret;
 }
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getTargetVelocities(const int n_joint, const int* joints, double* vels)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getRefVelocities(const int n_joint, const int* joints, double* vels)
+#endif
 {
     if (!joints || !vels) {return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH40;}
 
     YARP_DEV_RETURN_VALUE_TYPE_CH40 ret = YARP_DEV_RETURN_VALUE_OK_CH40;
     for (int i = 0; i < n_joint && ret; i++)
     {
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
         ret = getTargetVelocity(joints[i], &vels[i]);
+#else
+        ret = getRefVelocity(joints[i], &vels[i]);
+#endif
     }
     return ret;
 }
@@ -1558,7 +1663,7 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidOffset(const PidContro
     // TODO
     return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
-
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::setPidFeedforward(const PidControlTypeEnum& pidtype, int j, double v)
 {
     // TODO
@@ -1588,8 +1693,13 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getPidExtraInfos(const PidCo
     // TODO
     return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;
 }
+#endif
 
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool& enabled)
+#else
+YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::isPidEnabled(const PidControlTypeEnum& pidtype, int j, bool* enabled)
+#endif
 {
     // TODO
     return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH40;

--- a/tests/controlboard/ControlBoardCommonsTest.cc
+++ b/tests/controlboard/ControlBoardCommonsTest.cc
@@ -114,7 +114,11 @@ TEST(ControlBoardCommonsTest, JointPositionLimitsForMultipleJoints)
     for (int i = 0; i < expectedJointMaxLimits.size(); i++)
     {
         double maxLimit, minLimit;
+#ifdef YARP_DEV_RETURN_VALUE_IS_GE_40
+        iControlLimits->getPosLimits(i, &minLimit, &maxLimit);
+#else
         iControlLimits->getLimits(i, &minLimit, &maxLimit);
+#endif
         EXPECT_DOUBLE_EQ(maxLimit, expectedJointMaxLimits[i]);
         EXPECT_DOUBLE_EQ(minLimit, expectedJointMinLimits[i]);
     }

--- a/tests/controlboard/coupled_pendulum_two_controlboards.sdf
+++ b/tests/controlboard/coupled_pendulum_two_controlboards.sdf
@@ -171,7 +171,7 @@
         </yarpConfigurationFile>
         <initialConfiguration>0.0</initialConfiguration>
       </plugin>
-      <plugin name='robotinterface' filename='libgazebo_yarp_robotinterface.so'>
+      <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
       <yarpRobotInterfaceConfigurationFile>model://coupled_pendulum/conf/coupled_pendulum_nwsdafsads.xml</yarpRobotInterfaceConfigurationFile>
       </plugin>
 

--- a/tests/controlboard/coupled_pendulum_two_joints_single_controlboard.sdf
+++ b/tests/controlboard/coupled_pendulum_two_joints_single_controlboard.sdf
@@ -165,7 +165,7 @@
         </yarpConfigurationFile>
         <initialConfiguration>0.0</initialConfiguration>
       </plugin>
-      <!-- <plugin name='robotinterface' filename='libgazebo_yarp_robotinterface.so'>
+      <!-- <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
       <yarpRobotInterfaceConfigurationFile>model://coupled_pendulum/conf/coupled_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
       </plugin> -->
 

--- a/tests/depthcamera/CMakeLists.txt
+++ b/tests/depthcamera/CMakeLists.txt
@@ -1,3 +1,11 @@
+if(YARP_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  set(DEPTH_CAMERA_DEVICE_NAME "RGBDSensor_nws_yarp")
+else()
+  set(DEPTH_CAMERA_DEVICE_NAME "rgbdSensor_nws_yarp")
+endif()
+
+configure_file(depthcamera_nws.xml.in depthcamera_nws.xml @ONLY)
+
 add_executable(DepthCameraTest DepthCameraTest.cc)
 target_link_libraries(DepthCameraTest
   GTest::gtest_main

--- a/tests/depthcamera/depthcamera_nws.xml
+++ b/tests/depthcamera/depthcamera_nws.xml
@@ -3,7 +3,7 @@
 
 <robot name="camera" portprefix="camera" build="0"  xmlns:xi="http://www.w3.org/2001/XInclude">
     <devices>
-        <device name="depthcamera_nws_yarp" type="rgbdSensor_nws_yarp">            
+        <device name="depthcamera_nws_yarp" type="RGBDSensor_nws_yarp">
         <param name="name"> /depthcamera </param>
             <param name="period"> 0.033333 </param>
             <action phase="startup" level="5" type="attach">

--- a/tests/depthcamera/depthcamera_nws.xml.in
+++ b/tests/depthcamera/depthcamera_nws.xml.in
@@ -3,7 +3,7 @@
 
 <robot name="camera" portprefix="camera" build="0"  xmlns:xi="http://www.w3.org/2001/XInclude">
     <devices>
-        <device name="depthcamera_nws_yarp" type="RGBDSensor_nws_yarp">
+        <device name="depthcamera_nws_yarp" type="@DEPTH_CAMERA_DEVICE_NAME@">
         <param name="name"> /depthcamera </param>
             <param name="period"> 0.033333 </param>
             <action phase="startup" level="5" type="attach">


### PR DESCRIPTION
Starting from:

- https://github.com/robotology/gz-sim-yarp-plugins/pull/281

The goal is to have complete support for yarp4 but keeping backward compatibility with previous yarp versions.

cc @valegagge 