### PR TITLE
Add joint type handling for prismatic and revolute joints

### DIFF
--- a/plugins/controlboard/include/ControlBoardData.hh
+++ b/plugins/controlboard/include/ControlBoardData.hh
@@ -18,6 +18,7 @@
 #include <yarp/dev/IControlMode.h>
 #include <yarp/dev/IInteractionMode.h>
 #include <yarp/dev/IJointCoupling.h>
+#include <yarp/dev/IAxisInfo.h>
 #include <yarp/dev/PidEnums.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/os/Vocab.h>
@@ -61,7 +62,9 @@ struct CommonJointProperties {
 struct PhysicalJointProperties
 {
     CommonJointProperties commonJointProperties;
-    std::unordered_map<yarp::dev::PidControlTypeEnum, gz::math::PID, PidControlTypeEnumHashFunction> pidControllers;
+    yarp::dev::JointTypeEnum jointType{yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_REVOLUTE};
+    std::unordered_map<yarp::dev::PidControlTypeEnum, gz::math::PID, PidControlTypeEnumHashFunction>
+        pidControllers;
     std::string positionControlLaw; // TODO: verify usefulness of this field
 #if (YARP_VERSION_MAJOR > 3)
     std::vector<yarp::dev::PidControlTypeEnum> availablePids;

--- a/plugins/controlboard/src/ControlBoard.cpp
+++ b/plugins/controlboard/src/ControlBoard.cpp
@@ -272,10 +272,16 @@ bool ControlBoard::setJointProperties(EntityComponentManager& _ecm)
                 m_controlBoardData.physicalJoints[i].jointType =
                     yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_PRISMATIC;
             }
-            else
+            else if (jointTypeComponent != nullptr && jointTypeComponent->Data() == sdf::JointType::REVOLUTE)
             {
                 m_controlBoardData.physicalJoints[i].jointType =
                     yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_REVOLUTE;
+            } 
+            else 
+            {
+                yError() << "Joint " << jointFromConfigName
+                         << " has unsupported joint type. Only PRISMATIC and REVOLUTE are supported.";
+                return false;
             }
 
             // Initialize JointProperties object

--- a/plugins/controlboard/src/ControlBoard.cpp
+++ b/plugins/controlboard/src/ControlBoard.cpp
@@ -33,6 +33,8 @@
 #include <gz/sim/Types.hh>
 #include <gz/sim/Util.hh>
 #include <gz/sim/components/JointForceCmd.hh>
+#include <gz/sim/components/JointType.hh>
+#include <sdf/Joint.hh>
 #include <sdf/Element.hh>
 
 #include <yarp/dev/Drivers.h>
@@ -262,6 +264,19 @@ bool ControlBoard::setJointProperties(EntityComponentManager& _ecm)
             gzJoint.EnablePositionCheck(_ecm, true);
             gzJoint.EnableVelocityCheck(_ecm, true);
             gzJoint.EnableTransmittedWrenchCheck(_ecm, true);
+
+            auto jointTypeComponent = _ecm.Component<gz::sim::components::JointType>(jointEntity);
+
+            if (jointTypeComponent != nullptr && jointTypeComponent->Data() == sdf::JointType::PRISMATIC)
+            {
+                m_controlBoardData.physicalJoints[i].jointType =
+                    yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_PRISMATIC;
+            }
+            else
+            {
+                m_controlBoardData.physicalJoints[i].jointType =
+                    yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_REVOLUTE;
+            }
 
             // Initialize JointProperties object
             m_controlBoardData.physicalJoints[i].commonJointProperties.name = jointFromConfigName;

--- a/plugins/controlboard/src/ControlBoardData.cpp
+++ b/plugins/controlboard/src/ControlBoardData.cpp
@@ -152,25 +152,41 @@ bool ControlBoardData::setControlMode(int j, int mode)
 
 double ControlBoardData::convertGazeboGainToUserGain(PhysicalJointProperties& joint, double value)
 {
-    // TODO discriminate between joint types
+    if (joint.jointType == yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_PRISMATIC)
+    {
+        return value;
+    }
+
     return gzyarp::convertRadianGainToDegreeGains(value);
 }
 
 double ControlBoardData::convertGazeboToUser(PhysicalJointProperties& joint, double value)
 {
-    // TODO discriminate between joint types
+    if (joint.jointType == yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_PRISMATIC)
+    {
+        return value;
+    }
+
     return gzyarp::convertRadiansToDegrees(value);
 }
 
 double ControlBoardData::convertUserToGazebo(PhysicalJointProperties& joint, double value)
 {
-    // TODO discriminate between joint types
+    if (joint.jointType == yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_PRISMATIC)
+    {
+        return value;
+    }
+
     return gzyarp::convertDegreesToRadians(value);
 }
 
 double ControlBoardData::convertUserGainToGazeboGain(PhysicalJointProperties& joint, double value)
 {
-    // TODO discriminate between joint types
+    if (joint.jointType == yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_PRISMATIC)
+    {
+        return value;
+    }
+
     return gzyarp::convertDegreeGainToRadianGains(value);
 }
 

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -425,9 +425,15 @@ YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getAxisName(int axis, std::s
 
 YARP_DEV_RETURN_VALUE_TYPE_CH40 ControlBoardDriver::getJointType(int axis, yarp::dev::JointTypeEnum& type)
 {
-    // TODO integrate with IJointCoupled interface
+    std::lock_guard<std::mutex> lock(m_controlBoardData->mutex);
 
-    type = yarp::dev::JointTypeEnum::VOCAB_JOINTTYPE_REVOLUTE;
+    if (axis < 0 || axis >= m_controlBoardData->physicalJoints.size())
+    {
+        yError() << "Error while getting joint type: axis index out of range";
+        return false;
+    }
+
+    type = m_controlBoardData->physicalJoints.at(axis).jointType;
 
     return YARP_DEV_RETURN_VALUE_OK_CH40;
 }


### PR DESCRIPTION
## Summary
This PR adds joint-type-aware behavior to the ControlBoard plugin so prismatic joints are handled correctly (without angular unit conversions), while revolute joints keep the existing degree/radian conversion flow.

link to the comment detailing the issue encountered: https://github.com/mesh-iit/mobile-base/issues/197#issuecomment-4752829564

## Changes
1. Added joint type storage to per-joint physical properties.
2. Detected joint type from Gazebo joint components during plugin setup.
3. Updated conversion helpers to branch by joint type:
   - Prismatic joints: identity conversion (no degree/radian transforms).
   - Revolute joints: existing degree/radian and gain conversions.
4. Updated `getJointType(...)` to:
   - Return the stored joint type instead of always returning revolute.
   - Guard access with a mutex.
   - Validate axis bounds and report an error on invalid indices.
5. Added required YARP axis/joint type include for joint-type API support.

## Behavior Impact
- Fixes unit-conversion behavior for prismatic joints.
- Improves correctness of joint type reporting through the controlboard driver.
- Keeps revolute-joint behavior unchanged.

## Compatibility
- Backward compatible for existing revolute-only setups.
- No interface-breaking changes expected.